### PR TITLE
Add helper to generate rclone configs from JSON files

### DIFF
--- a/libsprinkle/rclone.py
+++ b/libsprinkle/rclone.py
@@ -11,8 +11,74 @@ __revision__ = "2"
 
 import logging
 import json
+import os
+import random
 from libsprinkle import common
 from libsprinkle import exceptions
+
+
+def generate_rclone_config(
+        json_dir,
+        output_file,
+        root_folder_id,
+        max_accounts=None,
+        prefix="dst",
+        start_index=101):
+    """Generate an rclone configuration from service account files.
+
+    The function scans ``json_dir`` for ``.json`` files, shuffles them to
+    provide a random selection and writes configuration sections for each
+    file.  Sections are named using ``prefix`` followed by a counter
+    starting at ``start_index``.
+
+    Parameters
+    ----------
+    json_dir: str
+        Directory containing the service account ``.json`` files.
+    output_file: str
+        Path where the generated configuration should be written.
+    root_folder_id: str
+        Google Drive root folder ID for each remote.
+    max_accounts: int, optional
+        Limit the number of JSON files processed.  When ``None`` all
+        files are used.
+    prefix: str, optional
+        Prefix for the remote names.  Defaults to ``dst``.
+    start_index: int, optional
+        Starting index for remote names.  Defaults to ``101``.
+
+    Returns
+    -------
+    str
+        The generated configuration content.
+    """
+    if not os.path.isdir(json_dir):
+        raise ValueError("Directory {} not found".format(json_dir))
+
+    files = [f for f in os.listdir(json_dir) if f.endswith(".json")]
+    files = random.sample(files, len(files))
+    if max_accounts is not None:
+        files = files[:max_accounts]
+
+    count = start_index - 1
+    lines = []
+    for filename in files:
+        count += 1
+        lines.extend([
+            "[{}{}]".format(prefix, count),
+            "type = drive",
+            "scope = drive",
+            "service_account_file = {}".format(
+                os.path.join(os.path.abspath(json_dir), filename)
+            ),
+            "root_folder_id = {}".format(root_folder_id),
+            "",
+        ])
+
+    config_text = "\n".join(lines)
+    with open(output_file, "w") as conf_fp:
+        conf_fp.write(config_text)
+    return config_text
 
 class RClone:
 

--- a/sprinkle.py
+++ b/sprinkle.py
@@ -21,6 +21,7 @@ import getopt
 import sys
 import traceback
 import os
+import tempfile
 try:
     from filelock import Timeout, FileLock
 except:
@@ -30,6 +31,7 @@ except:
 
 lock = FileLock("sprinkle.lock", timeout=1)
 
+__drive_id = None
 
 def warranty():
     """
@@ -88,6 +90,9 @@ OPTIONS:
     --log-file {file}            logs output to the specified file
     --no-cache                   turn off caching
     --rclone-conf {config file}  rclone configuration (default:None)
+    --rclone-sa-dir {dir}        build rclone config from service accounts
+    --rclone-sa-count {num}      limit number of service accounts used
+    --drive-id {id}              Google Drive folder ID for rclone config
     --rclone-exe {rclone_exe}    rclone executable (default:rclone)
     --restore-duplicates         restore files if duplicates are found (default:false)
     --retries {num_retries}      number of retries (default:1)
@@ -393,6 +398,7 @@ def read_args(argv):
     global __comp_method
     global __rclone_exe
     global __rclone_conf
+    global __drive_id
     global __display_unit
     global __rclone_retries
     global __show_progress
@@ -424,6 +430,7 @@ def read_args(argv):
     __comp_method = None
     __rclone_exe = None
     __rclone_conf = None
+    __drive_id = None
     __display_unit = None
     __rclone_retries = None
     __show_progress = None
@@ -449,6 +456,9 @@ def read_args(argv):
     __daemon_interval = None
     __daemon_pidfile = None
 
+    rclone_sa_dir = None
+    rclone_sa_count = None
+
     try:
         opts, args = getopt.getopt(argv, "dvhc:s:",
                                    ["help",
@@ -459,6 +469,9 @@ def read_args(argv):
                                     "comp-method=",
                                     "rclone-exe=",
                                     "rclone-conf=",
+                                    "rclone-sa-dir=",
+                                    "rclone-sa-count=",
+                                    "drive-id=",
                                     "stats=",
                                     "display-unit=",
                                     "rclone-retries=",
@@ -507,6 +520,12 @@ def read_args(argv):
             __rclone_exe = arg
         elif opt in ("--rclone-conf"):
             __rclone_conf = arg
+        elif opt in ("--rclone-sa-dir"):
+            rclone_sa_dir = arg
+        elif opt in ("--rclone-sa-count"):
+            rclone_sa_count = int(arg)
+        elif opt in ("--drive-id"):
+            __drive_id = arg
         elif opt in ("--display-unit"):
             if arg != 'G' and arg != 'M' and arg != 'K' and arg != 'B':
                 logging.error('invalid UNIT ' + arg + ', only [G|M|K|B] accepted')
@@ -557,6 +576,16 @@ def read_args(argv):
         elif opt in ("--daemon-pidfile"):
             __daemon_pidfile = arg
 
+    if rclone_sa_dir is not None:
+        if __drive_id is None:
+            raise Exception("--drive-id option is required when using --rclone-sa-dir")
+        fd, tmp_conf = tempfile.mkstemp(prefix="rclone-", suffix=".conf")
+        os.close(fd)
+        rclone.generate_rclone_config(
+            rclone_sa_dir, tmp_conf, __drive_id, max_accounts=rclone_sa_count
+        )
+        __rclone_conf = tmp_conf
+
     if len(args) < 1 and __check_prereq is None:
         usage()
         sys.exit()
@@ -566,6 +595,7 @@ def read_args(argv):
 
 def configure(config_file):
     global __config
+    global __drive_id
 
     _default_values = {
         "debug": False,
@@ -614,6 +644,9 @@ def configure(config_file):
 
     if __rclone_conf is not None:
         __config['rclone_config'] = __rclone_conf
+
+    if __drive_id is not None:
+        __config['drive_id'] = __drive_id
 
     if __rclone_retries is not None:
         __config['rclone_retries'] = str(__rclone_retries)

--- a/tests/test_generate_rclone_config.py
+++ b/tests/test_generate_rclone_config.py
@@ -1,0 +1,23 @@
+import os
+import sys
+
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
+from libsprinkle import rclone
+
+
+def test_generate_rclone_config(tmp_path):
+    sa_dir = tmp_path / "accounts"
+    sa_dir.mkdir()
+
+    for i in range(3):
+        (sa_dir / f"{i}.json").write_text("{}")
+
+    output = tmp_path / "rclone.conf"
+    content = rclone.generate_rclone_config(
+        str(sa_dir), str(output), "drive-id", max_accounts=2, start_index=1
+    )
+
+    assert output.read_text() == content
+    assert content.count("[dst") == 2
+    assert "root_folder_id = drive-id" in content
+

--- a/tests/test_rclone_sa_dir_option.py
+++ b/tests/test_rclone_sa_dir_option.py
@@ -1,0 +1,24 @@
+from pathlib import Path
+import sprinkle
+
+
+def test_rclone_sa_dir_option(tmp_path):
+    sa_dir = tmp_path / "accounts"
+    sa_dir.mkdir()
+    for i in range(2):
+        (sa_dir / f"{i}.json").write_text("{}")
+    sprinkle.read_args([
+        "--rclone-sa-dir",
+        str(sa_dir),
+        "--rclone-sa-count",
+        "1",
+        "--drive-id",
+        "drive-id",
+        "ls",
+    ])
+    conf_path = Path(sprinkle.__rclone_conf)
+    assert conf_path.exists()
+    content = conf_path.read_text()
+    assert "root_folder_id = drive-id" in content
+    assert content.count("[dst") == 1
+    conf_path.unlink()


### PR DESCRIPTION
## Summary
- randomize service-account list when generating rclone configs
- add `--rclone-sa-count` flag to limit number of accounts used
- test service-account count option

## Testing
- `python -m py_compile libsprinkle/rclone.py sprinkle.py tests/test_generate_rclone_config.py tests/test_rclone_sa_dir_option.py`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_689fcea387d883288b1c055618214d61