### PR TITLE
Add optional rclone move mode

### DIFF
--- a/README.md
+++ b/README.md
@@ -102,6 +102,7 @@ and the command specific help.
     --rclone-sa-count {num}      limit number of service accounts used
     --drive-id {id}              Google Drive folder ID for rclone config
     --rclone-exe {rclone_exe}    rclone executable (default:rclone)
+    --rclone-move                use 'rclone move' instead of 'rclone copy' (default:false)
     --restore-duplicates         restore files if duplicates are found (default:false)
     --retries {num_retries}      number of retries (default:1)
     --show-progress              show progress

--- a/libsprinkle/clsync.py
+++ b/libsprinkle/clsync.py
@@ -80,7 +80,14 @@ class ClSync:
         if 'rclone_exe' not in self._config:
             self._rclone = rclone.RClone(rclone_config)
         else:
-            self._rclone = rclone.RClone(rclone_config, self._config['rclone_exe'], self._rclone_retries)
+            self._rclone = rclone.RClone(
+                rclone_config, self._config['rclone_exe'], self._rclone_retries
+            )
+
+        if 'rclone_move' in config:
+            self._rclone_move = config['rclone_move']
+        else:
+            self._rclone_move = False
 
     def get_remotes(self):
         logging.debug('getting rclone remotes')
@@ -486,11 +493,17 @@ class ClSync:
 
     def copy(self, src, dst, remote):
         logging.debug('copy ' + src + ' to ' + remote + dst)
-        self._rclone.copy(src, remote+dst)
+        if self._rclone_move:
+            self._rclone.move(src, remote+dst)
+        else:
+            self._rclone.copy(src, remote+dst)
 
     def copy_new(self, src, dst, no_error=False):
         logging.debug('copy ' + src + ' to ' + dst)
-        self._rclone.copy(src, dst, [], no_error)
+        if self._rclone_move:
+            self._rclone.move(src, dst)
+        else:
+            self._rclone.copy(src, dst, [], no_error)
 
     def move(self, src, dst):
         logging.debug('move ' + src + ' to ' + dst)

--- a/sprinkle.conf
+++ b/sprinkle.conf
@@ -42,6 +42,11 @@
 # dry_run: dry run mode
 # dry_run=false
 
+# rclone_move: move files instead of copying them
+# rclone_move=false (copy files and keep sources) (default)
+# rclone_move=true (remove source files after transfer)
+# rclone_move=false
+
 # delete_files: delete files after 1-way sync
 # delete_files=false (leave files not locally present on remote drives)
 # delete_files=true (delete files not locally present from remote drives) (default)

--- a/sprinkle.py
+++ b/sprinkle.py
@@ -94,6 +94,7 @@ OPTIONS:
     --rclone-sa-count {num}      limit number of service accounts used
     --drive-id {id}              Google Drive folder ID for rclone config
     --rclone-exe {rclone_exe}    rclone executable (default:rclone)
+    --rclone-move                use 'rclone move' instead of 'rclone copy' (default:false)
     --restore-duplicates         restore files if duplicates are found (default:false)
     --retries {num_retries}      number of retries (default:1)
     --show-progress              show progress
@@ -404,6 +405,7 @@ def read_args(argv):
     global __rclone_retries
     global __show_progress
     global __delete_files
+    global __rclone_move
     global __restore_duplicates
     global __dry_run
     global __smtp_enable
@@ -437,6 +439,7 @@ def read_args(argv):
     __rclone_retries = None
     __show_progress = None
     __delete_files = None
+    __rclone_move = None
     __restore_duplicates = False
     __dry_run = None
     __smtp_enable = None
@@ -478,6 +481,7 @@ def read_args(argv):
                                     "stats=",
                                     "display-unit=",
                                     "rclone-retries=",
+                                    "rclone-move",
                                     "show-progress",
                                     "dry-run",
                                     "delete-files",
@@ -541,6 +545,8 @@ def read_args(argv):
             __show_progress = True
         elif opt in ("--delete-files"):
             __delete_files = True
+        elif opt in ("--rclone-move"):
+            __rclone_move = True
         elif opt in ("--restore-duplicates"):
             __restore_duplicates = True
         elif opt in ("--dry-run"):
@@ -603,12 +609,14 @@ def read_args(argv):
 def configure(config_file):
     global __config
     global __drive_id
+    global __rclone_move
 
     _default_values = {
         "debug": False,
         "dry_run": False,
         "show_progress": False,
         "delete_files": False,
+        "rclone_move": False,
         "restore_duplicates": False,
         "smtp_enable": False,
         "no_cache": False,
@@ -664,6 +672,9 @@ def configure(config_file):
 
     if __delete_files is not None:
         __config['delete_files'] = __delete_files
+
+    if __rclone_move is not None:
+        __config['rclone_move'] = __rclone_move
 
     if __dry_run is not None:
         __config['dry_run'] = __dry_run

--- a/tests/test_rclone_move_option.py
+++ b/tests/test_rclone_move_option.py
@@ -1,0 +1,9 @@
+import sprinkle
+
+def test_rclone_move_option():
+    sprinkle.read_args([
+        "--rclone-move",
+        "ls",
+    ])
+    sprinkle.configure(None)
+    assert sprinkle.__config["rclone_move"] is True


### PR DESCRIPTION
## Summary
- allow opting into `rclone move` instead of the default `rclone copy`
- document the new `--rclone-move` flag and configuration option
- test parsing of the move flag

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68a0978896208328853de569df03e075