### PR TITLE
added new caching options

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,24 @@
+# Sprinkle Agent Instructions
+
+This file applies to `sprinkle` and all child paths.
+
+## Service Account Safety
+
+- Google Drive service account JSON files contain secrets. Never print, log, commit, snapshot, or paste raw `private_key` values.
+- Use synthetic service-account fixtures in tests. Do not use files from `/Users/user/workspace/svcacc` in committed tests or docs.
+- Service-account cleanup must be quarantine-first. Source deletion is allowed only when a user explicitly selects a delete mode.
+- Most Google Drive service accounts in this workspace are effectively limited to about 10-15 GB, so code should be designed around many small quotas and cached quota data.
+- `sa-import` should validate new accounts with rclone when available. Unknown quota during import is an invalid state and should quarantine the affected account by default.
+
+## Implementation Rules
+
+- Prefer Python stdlib and existing project patterns. Do not add dependencies without explicit approval.
+- Keep `--rclone-sa-dir` backward-compatible: existing callers should still get a generated rclone config from service-account files.
+- Cache-aware code must keep unknown/error quota states distinct from real byte values. Do not use fake `1` byte quota values as a fallback.
+- Avoid filename-based service-account identity. Dedupe by parsed account data such as `client_email`, `private_key_id`, and content hash.
+- Large-file upload placement must remain deterministic and capacity-aware. Keep a real free-space headroom check for large files instead of relying on random service-account selection.
+
+## Verification
+
+- Add regression tests for behavior changes, using generated JSON fixtures only.
+- Run available local checks before reporting completion. If `pytest` is unavailable, run targeted stdlib checks such as `unittest`, `compileall`, and small synthetic CLI smoke tests.

--- a/README.md
+++ b/README.md
@@ -8,12 +8,34 @@ backup and recovery. Sprinkle uses the excellent [RClone](https://rclone.org) so
 
 * Docker Image [dbiesecke/sprinkle](https://hub.docker.com/r/dbiesecke/sprinkle)
   
-* load sa accounts from directory, random selection, gdrive_id option & with limiter
+* load sa accounts from directory with import, dedupe, gdrive_id option & limiter
 
 ```bash
 # will load 5 sa accounts from /etc/rclone/sa & root_folder it is set to "XXXXX" ( your public gdrive dir)
 
 $ docker run -i -v /etc/rclone:/etc/rclone:ro dbiesecke/sprinkle --rclone-sa-count 5 --drive-id XXXXX -d --rclone-sa-dir /etc/rclone/sa stats
+```
+
+* import, dedupe, validate, quarantine, and cache Google Drive service account quota data
+
+```bash
+$ ./sprinkle.py sa-import /etc/rclone/sa
+$ ./sprinkle.py --drive-id XXXXX sa-stats
+```
+
+`sa-import` validates new accounts with `rclone about --json` and prints per-file progress. If rclone returns an error or quota remains unknown, the account is recorded as invalid and quarantined by default.
+
+Sprinkle keeps upload placement capacity-aware for large files: service accounts are selected by known free space, with extra headroom for files of at least 1 GiB so a large movie is not sent to an account that only barely fits it.
+
+* create a home-directory configuration with interactive defaults
+
+```bash
+$ ./sprinkle.py config
+# writes ~/.sprinkle/sprinkle.conf, including:
+# --rclone-sa-count 5 --drive-id XXXXX -d --rclone-sa-dir /etc/rclone/sa
+# sa_cache_ttl_hours=72
+# sa_refresh=stale
+# sa_clean_invalid=quarantine
 ```
 
 
@@ -34,11 +56,13 @@ pip3 install sprinkle-py
 
 Or by cloning the repository to your running machine, but make sure prerequisites are met:
 ```
-git clone https://gitlab.com/mmontuori/sprinkle.git
+git clone https://gitlab.com/dbiesecke/sprinkle.git
 cd sprinkle
-./sprinkle.py -c sprinkle.conf ls /
+sprinkle.py config
+sprinkle.py sa-import /your/sa/accounts
+sprinkle.py sa-stats 
 ```
-A more comprehensive guide can be found [here](https://mmontuori.github.io/sprinkle/docs/guide)
+A more comprehensive guide can be found [here](https://dbiesecke.github.io/sprinkle/docs/guide)
 
 ## Prerequisites
 
@@ -101,6 +125,12 @@ and the command specific help.
     --rclone-sa-dir {dir}        build rclone config from service accounts
     --rclone-sa-count {num}      limit number of service accounts used
     --drive-id {id}              Google Drive folder ID for rclone config
+    --sa-db {file}               service account registry database
+    --sa-store {dir}             managed service account store
+    --sa-cache-ttl-hours {num}   hours before cached SA quota is stale (default:72)
+    --sa-refresh {mode}          SA quota refresh [missing|stale|all|none] (default:stale)
+    --sa-clean-invalid {mode}    invalid SA cleanup [none|quarantine|delete] (default:quarantine)
+    --sa-group-size {num}        preferred SA grouping size for generated operator configs
     --rclone-exe {rclone_exe}    rclone executable (default:rclone)
     --rclone-move                use 'rclone move' instead of 'rclone copy' (default:false)
     --restore-duplicates         restore files if duplicates are found (default:false)
@@ -115,7 +145,7 @@ and the command specific help.
 
 * **Michael Montuori** - *Head developer* - [mmontuori](https://gitlab.com/mmontuori)
 * **Daniel** - *Fork* [dbiesecke](https://gitlab.com/dbiesecke)
-
+#
 ## License
 
 This project is licensed under the GPLv3 License - see the

--- a/docs/guide.md
+++ b/docs/guide.md
@@ -126,6 +126,29 @@ As long as RClone is configured correctly with volumes, Sprinkle works out of th
 Sprinkle can be configured by editing the file sprinkle.conf. The file that ships with sprinkle
 has all default values assigned which work for most installations, however, it's possible that
 values have to be tweaked for specific installations. All values in sprinkle.conf are commented.
+The recommended way to create a local configuration is the interactive config command. By default it
+writes to `~/.sprinkle/sprinkle.conf`.
+
+##### interactive configuration:
+```
+$ python3 sprinkle.py config
+rclone_move: move files instead of copying them [Y/n]: Y
+delete_files: delete files after 1-way sync [y/N]:
+debug output (-d) [Y/n]:
+rclone_sa_count [5]:
+drive_id [XXXXX]: GDRIVE_FOLDER_ID
+rclone_sa_dir [/etc/rclone/sa]:
+sa_cache_ttl_hours [72]:
+sa_refresh {missing|stale|all|none} [stale]:
+sa_clean_invalid {none|quarantine|delete} [quarantine]:
+```
+
+The generated config can also store defaults equivalent to:
+
+```
+--rclone-sa-count 5 --drive-id GDRIVE_FOLDER_ID -d --rclone-sa-dir /etc/rclone/sa
+```
+
 For example, the **debug** value
 ##### sprinkle.conf debug value:
 ```
@@ -142,12 +165,58 @@ debug=true
 This modification will set the debug value to true and output additional information that can be
 used for development or troubleshooting.
 
+### Configure Google Drive Service Accounts
+Sprinkle can import Google Drive service-account JSON files into a managed local store, dedupe them,
+validate them with `rclone about --json`, and cache quota data in SQLite. Service-account JSON files
+contain secrets, so do not commit or paste raw `private_key` values.
+
+##### import service accounts:
+```
+$ python3 sprinkle.py sa-import /path/to/service-accounts
+service account import: found 46 json files
+service account import [1/46] imported: sa-77757096d8ee3b33cf290d6a.json
+service account import [2/46] imported: sa-774a8b4465f01f42f1e45016.json
+...
+service account import complete
+scanned:      46
+validated:    46
+imported:     46
+duplicates:   0
+invalid:      0
+validation errors: 0
+quarantined:  0
+deleted:      0
+store:        /home/user/.sprinkle/service-accounts
+database:     /home/user/.sprinkle/sa-cache.sqlite3
+```
+
+Invalid JSON files, rejected service accounts, missing projects/users, and unknown quota results are
+recorded as invalid. With the default `sa_clean_invalid=quarantine`, the affected JSON file is copied
+to the managed quarantine directory instead of being deleted from the source path.
+
+##### inspect imported accounts and cached quota:
+```
+$ python3 sprinkle.py --drive-id GDRIVE_FOLDER_ID sa-stats
+SERVICE ACCOUNT SUMMARY
+active:      46
+duplicates:  0
+invalid:     0
+refreshed:   0
+errors:      0
+stale:       0
+unknown:     0
+```
+
+Most Google Drive service accounts are effectively small 10-15 GB quotas. Sprinkle therefore uses the
+cached quota data for placement and keeps extra headroom for large files so uploads are not sent to an
+account that only barely fits the file.
+
 ## Verify
 ### Verify Sprinkle->RClone->Volumes Connections
 To verify proper Sprinkle operation, use any commands, like the stats command:
 ##### for Windows:
 ```
-C:\>python sprinkle.py --version
+C:\>python sprinkle.py stats
 calculating total and free space...
 REMOTE                          SIZE                 FREE      %FREE
 =============== ==================== ==================== ==========
@@ -239,11 +308,14 @@ DESCRIPTION:
     Sprinkle uses the excellent [RClone](https://rclone.org) software for cloud volume access.
 
 EXAMPLES:
+    sprinkle.py config
     sprinkle.py ls /backup
     sprinkle.py backup /dir_to_backup
     sprinkle.py restore /backup /opt/restore_dir
     sprinkle.py stats
     sprinkle.py -c /home/sprinkle/sprinkle.conf ls /backup
+    sprinkle.py sa-import /path/to/service-accounts
+    sprinkle.py --drive-id GDRIVE_FOLDER_ID sa-stats
 ...
 ...
 ```
@@ -262,11 +334,14 @@ DESCRIPTION:
     Sprinkle uses the excellent [RClone](https://rclone.org) software for cloud volume access.
 
 EXAMPLES:
+    sprinkle.py config
     sprinkle.py ls /backup
     sprinkle.py backup /dir_to_backup
     sprinkle.py restore /backup /opt/restore_dir
     sprinkle.py stats
     sprinkle.py -c /home/sprinkle/sprinkle.conf ls /backup
+    sprinkle.py sa-import /path/to/service-accounts
+    sprinkle.py --drive-id GDRIVE_FOLDER_ID sa-stats
 ...
 ...
 ```
@@ -282,4 +357,3 @@ We use [SemVer](http://semver.org/) for versioning. For the versions available, 
 
 ## License
 This project is licensed under the GPLv3 License - see the [LICENSE.md](https://github.com/mmontuori/sprinkle/LICENSE) file for details
-

--- a/libsprinkle/clsync.py
+++ b/libsprinkle/clsync.py
@@ -15,6 +15,7 @@ from libsprinkle import common
 from libsprinkle import clfile
 from libsprinkle import exceptions
 from libsprinkle import operation
+from libsprinkle import service_accounts
 try:
     from progress.bar import Bar
 except:
@@ -23,6 +24,10 @@ except:
 import json
 import os
 import re
+
+DEFAULT_LARGE_FILE_THRESHOLD_BYTES = 1024 * 1024 * 1024
+DEFAULT_LARGE_FILE_MIN_FREE_BYTES = 512 * 1024 * 1024
+DEFAULT_LARGE_FILE_MIN_FREE_PERCENT = 5
 
 class ClSync:
 
@@ -47,6 +52,26 @@ class ClSync:
             self._distribution_type = 'mas'
         if self._distribution_type == 'mas':
             self._cached_free = {}
+        self._sa_registry = None
+        self._sa_refresh = config.get('sa_refresh', service_accounts.DEFAULT_REFRESH_MODE)
+        self._large_file_threshold_bytes = int(config.get(
+            'large_file_threshold_bytes',
+            DEFAULT_LARGE_FILE_THRESHOLD_BYTES,
+        ))
+        self._large_file_min_free_bytes = int(config.get(
+            'large_file_min_free_bytes',
+            DEFAULT_LARGE_FILE_MIN_FREE_BYTES,
+        ))
+        self._large_file_min_free_percent = int(config.get(
+            'large_file_min_free_percent',
+            DEFAULT_LARGE_FILE_MIN_FREE_PERCENT,
+        ))
+        if config.get('sa_db') is not None:
+            self._sa_registry = service_accounts.ServiceAccountRegistry(
+                config.get('sa_db'),
+                config.get('sa_store'),
+                config.get('sa_cache_ttl_hours', service_accounts.DEFAULT_CACHE_TTL_HOURS),
+            )
         if 'compare_method' in config:
             self._compare_method = config['compare_method']
         else:
@@ -103,9 +128,10 @@ class ClSync:
             logging.debug('creating directory ' + remote + directory)
             self._rclone.mkdir(remote, directory)
 
-    def ls(self, file, with_dups=False, regex=None):
+    def ls(self, file, with_dups=False, regex=None, stop_after_first=None):
         logging.debug('lsjson of file: ' + file)
-        stop_after_first=self._config['ls_stop_first']
+        if stop_after_first is None:
+            stop_after_first=self._config['ls_stop_first']
         if self._config['no_cache'] is False and self._cache is not None:
             logging.debug('serving cached version of file list...')
             self._cache_counter += 1
@@ -190,7 +216,8 @@ class ClSync:
         if self._sizes is None:
             self._sizes = {}
             for remote in self.get_remotes():
-                size = self._rclone.get_size(remote)
+                quota = self._get_remote_quota(remote)
+                size = self._quota_value(quota, 'total')
                 logging.debug('size of ' + remote + ' is ' + str(size))
                 self._sizes[remote] = size
         return self._sizes
@@ -200,11 +227,13 @@ class ClSync:
         total_size = 0
         for remote in self.get_remotes():
             if self._sizes is None:
-                size = self._rclone.get_size(remote)
+                quota = self._get_remote_quota(remote)
+                size = self._quota_value(quota, 'total')
             else:
                 size = self._sizes[remote]
             logging.debug('size of ' + remote + ' is ' + str(size))
-            total_size += size
+            if size is not None:
+                total_size += size
         return total_size
 
     def get_frees(self):
@@ -212,7 +241,8 @@ class ClSync:
         if self._frees is None:
             self._frees = {}
             for remote in self.get_remotes():
-                size = self._rclone.get_free(remote)
+                quota = self._get_remote_quota(remote)
+                size = self._quota_value(quota, 'free')
                 logging.debug('free of ' + remote + ' is ' + str(size))
                 self._frees[remote] = size
         return self._frees
@@ -222,45 +252,120 @@ class ClSync:
         total_size = 0
         for remote in self.get_remotes():
             if self._frees is None:
-                size = self._rclone.get_free(remote)
+                quota = self._get_remote_quota(remote)
+                size = self._quota_value(quota, 'free')
             else:
                 size = self._frees[remote]
             logging.debug('free of ' + remote + ' is ' + str(size))
-            total_size += size
+            if size is not None:
+                total_size += size
         return total_size
 
     def get_max_file_size(self):
         logging.debug('getting total maximum file size')
         total_size = 0
         for remote in self.get_remotes():
-            size = self._rclone.get_free(remote)
+            quota = self._get_remote_quota(remote)
+            size = self._quota_value(quota, 'free')
             logging.debug('free of ' + remote + ' is ' + str(size))
-            if size > total_size:
+            if size is not None and size > total_size:
                 total_size = size
         return total_size
 
     def get_best_remote(self, requested_size=1):
         if self._distribution_type == 'mas':
-            logging.debug('selecting best remote with the most available space to store size: ' + str(requested_size))
+            required_size = self._required_free_for_upload(requested_size)
+            logging.debug(
+                'selecting best remote with the most available space to store size: ' +
+                str(requested_size) + ', required free: ' + str(required_size)
+            )
             best_remote = None
             highest_size = 0
             size = 0
             for remote in self.get_remotes():
-                if remote not in self._cached_free:
-                    size = self._rclone.get_free(remote)
-                    self._cached_free[remote] = size
-                else:
-                    size = self._cached_free[remote]
+                size = self._known_free_for_remote(remote)
                 logging.debug('free of ' + remote + ' is ' + str(size))
-                if size > highest_size:
-                    if requested_size <= size:
+                if size is not None and size > highest_size:
+                    if required_size <= size:
                         highest_size = size
                         best_remote = remote
-            self._cached_free[best_remote] = highest_size - requested_size
+            if best_remote is None:
+                raise Exception(
+                    'no remote has enough known free space for requested size ' +
+                    str(requested_size) + ' with required free ' + str(required_size)
+                )
             return best_remote
         else:
             logging.error('distribution mode ' + self._distribution_type + ' not supported.')
             raise Exception('unsupported distribution mode ' + self._distribution_type)
+
+    def ensure_remote_has_enough_space(self, remote, requested_size):
+        required_size = self._required_free_for_upload(requested_size)
+        free_size = self._known_free_for_remote(remote)
+        if free_size is None or free_size < required_size:
+            raise Exception(
+                'remote ' + remote + ' does not have enough known free space for requested size ' +
+                str(requested_size) + ' with required free ' + str(required_size)
+            )
+        return remote
+
+    def _known_free_for_remote(self, remote):
+        if remote not in self._cached_free:
+            quota = self._get_remote_quota(remote)
+            self._cached_free[remote] = self._quota_value(quota, 'free')
+        return self._cached_free[remote]
+
+    def _required_free_for_upload(self, requested_size):
+        requested_size = int(requested_size)
+        if requested_size < self._large_file_threshold_bytes:
+            return requested_size
+        percent_margin = int(requested_size * self._large_file_min_free_percent / 100)
+        margin = max(self._large_file_min_free_bytes, percent_margin)
+        return requested_size + margin
+
+    def mark_remote_used(self, remote, size):
+        if self._distribution_type == 'mas':
+            if remote in self._cached_free and self._cached_free[remote] is not None:
+                self._cached_free[remote] = max(0, self._cached_free[remote] - int(size))
+            if self._frees is not None and remote in self._frees and self._frees[remote] is not None:
+                self._frees[remote] = max(0, self._frees[remote] - int(size))
+        if self._sa_registry is not None:
+            self._sa_registry.adjust_quota_for_remote(remote, int(size))
+
+    def _get_remote_quota(self, remote):
+        cached = None
+        if self._sa_registry is not None:
+            cached = self._sa_registry.quota_by_remote(remote)
+            if cached is not None and not self._sa_registry.should_refresh(cached, self._sa_refresh):
+                return self._quota_from_row(cached)
+            if cached is not None and self._sa_refresh == 'none':
+                return self._quota_from_row(cached)
+        try:
+            quota = self._rclone.get_about_json(remote, True)
+        except Exception as e:
+            logging.debug('error refreshing quota for ' + remote + ': ' + str(e))
+            quota = None
+        if self._sa_registry is not None and cached is not None:
+            if quota is None:
+                self._sa_registry.update_quota_for_remote(remote, None, 'rclone about failed')
+                return self._quota_from_row(cached)
+            self._sa_registry.update_quota_for_remote(remote, quota, None)
+        return quota
+
+    def _quota_from_row(self, row):
+        if row is None:
+            return None
+        quota = {}
+        for key in ('total', 'used', 'free', 'trashed', 'other', 'objects'):
+            quota[key] = row[key]
+        if all(quota[key] is None for key in quota):
+            return None
+        return quota
+
+    def _quota_value(self, quota, key):
+        if quota is None:
+            return None
+        return quota.get(key)
 
     def index_local_dir(self, local_dir, exclusion_list=None):
         common.print_line('indexing local directory: ' + local_dir + '...')
@@ -417,9 +522,9 @@ class ClSync:
                                   ' -> ' + best_remote+':'+op.src.remote_path)
                 if dry_run is False:
                     self.copy(op.src.path+'/'+op.src.name, op.src.remote_path, best_remote)
+                    self.mark_remote_used(best_remote, int(op.src.size))
             if op.operation == operation.Operation.UPDATE:
-                best_remote = self.get_best_remote(int(op.src.size))
-                logging.debug('best remote: ' + best_remote)
+                self.ensure_remote_has_enough_space(op.src.remote, int(op.src.size))
                 if not self._show_progress:
                     common.print_line('backing up file ' + op.src.path + '/' + op.src.name +
                                   ' -> ' + op.src.remote + ':' + op.src.remote_path)

--- a/libsprinkle/config.py
+++ b/libsprinkle/config.py
@@ -71,7 +71,8 @@ class Config(object):
             logging.error("File " + self._config_file + " not found")
             raise Exception("File " + self._config_file + " not found")
         else:
-            config_str = '[' + self._CONFIG_MAIN_SECTION + ']\n' + open(self._config_file, 'r').read()
+            with open(self._config_file, 'r') as fp:
+                config_str = '[' + self._CONFIG_MAIN_SECTION + ']\n' + fp.read()
             try:
                 config_fp = StringIO.StringIO(config_str)
             except:
@@ -80,7 +81,10 @@ class Config(object):
                 self._conf_obj = ConfigParser.RawConfigParser()
             except:
                 self._conf_obj = configparser.RawConfigParser()
-            self._conf_obj.readfp(config_fp)
+            try:
+                self._conf_obj.read_file(config_fp)
+            except AttributeError:
+                self._conf_obj.readfp(config_fp)
 
     def get_config(self):
         retconf = {}

--- a/libsprinkle/rclone.py
+++ b/libsprinkle/rclone.py
@@ -23,13 +23,14 @@ def generate_rclone_config(
         root_folder_id,
         max_accounts=None,
         prefix="dst",
-        start_index=101):
+        start_index=101,
+        return_entries=False,
+        shuffle=True):
     """Generate an rclone configuration from service account files.
 
-    The function scans ``json_dir`` for ``.json`` files, shuffles them to
-    provide a random selection and writes configuration sections for each
-    file.  Sections are named using ``prefix`` followed by a counter
-    starting at ``start_index``.
+    The function scans ``json_dir`` for ``.json`` files and writes
+    configuration sections for each file. Sections are named using
+    ``prefix`` followed by a counter starting at ``start_index``.
 
     Parameters
     ----------
@@ -55,26 +56,87 @@ def generate_rclone_config(
     if not os.path.isdir(json_dir):
         raise ValueError("Directory {} not found".format(json_dir))
 
-    files = [f for f in os.listdir(json_dir) if f.endswith(".json")]
-    files = random.sample(files, len(files))
+    files = [
+        os.path.join(os.path.abspath(json_dir), f)
+        for f in os.listdir(json_dir)
+        if f.endswith(".json")
+    ]
+    return generate_rclone_config_from_files(
+        files,
+        output_file,
+        root_folder_id,
+        max_accounts=max_accounts,
+        prefix=prefix,
+        start_index=start_index,
+        return_entries=return_entries,
+        shuffle=shuffle,
+    )
+
+
+def generate_rclone_config_from_files(
+        json_files,
+        output_file,
+        root_folder_id=None,
+        max_accounts=None,
+        prefix="dst",
+        start_index=101,
+        return_entries=False,
+        shuffle=True):
+    """Generate an rclone configuration from explicit service account files."""
+    files = [os.path.abspath(path) for path in json_files]
+    if shuffle:
+        files = random.sample(files, len(files))
+    else:
+        files = sorted(files)
     if max_accounts is not None:
         files = files[:max_accounts]
 
     count = start_index - 1
     lines = []
+    entries = []
     for filename in files:
         count += 1
+        remote = "{}{}".format(prefix, count)
         lines.extend([
-            "[{}{}]".format(prefix, count),
+            "[{}]".format(remote),
             "type = drive",
             "scope = drive",
-            "service_account_file = {}".format(
-                os.path.join(os.path.abspath(json_dir), filename)
-            ),
-            "root_folder_id = {}".format(root_folder_id),
+            "service_account_file = {}".format(filename),
+        ])
+        if root_folder_id:
+            lines.append("root_folder_id = {}".format(root_folder_id))
+        lines.append("")
+        entries.append({"remote": remote, "path": filename})
+
+    config_text = "\n".join(lines)
+    with open(output_file, "w") as conf_fp:
+        conf_fp.write(config_text)
+    if return_entries:
+        return config_text, entries
+    return config_text
+
+
+def generate_rclone_combine_config(upstreams, output_file, group_size=50, prefix="sa_group"):
+    """Generate optional rclone combine remotes from upstream specs."""
+    if group_size < 1:
+        raise ValueError("group_size must be at least 1")
+    specs = []
+    for upstream in upstreams:
+        if isinstance(upstream, dict):
+            remote = upstream["remote"].rstrip(":")
+            specs.append("{}={}:".format(remote, remote))
+        else:
+            specs.append(str(upstream))
+    lines = []
+    group = 1
+    for index in range(0, len(specs), group_size):
+        lines.extend([
+            "[{}{}]".format(prefix, group),
+            "type = combine",
+            "upstreams = {}".format(" ".join(specs[index:index + group_size])),
             "",
         ])
-
+        group += 1
     config_text = "\n".join(lines)
     with open(output_file, "w") as conf_fp:
         conf_fp.write(config_text)
@@ -87,7 +149,7 @@ class RClone:
         if config_file is not None and not common.is_file(config_file):
             logging.error("configuration file " + str(config_file) + " not found. Cannot continue!")
             raise Exception("Configuration file " + str(config_file) + " not found")
-        if rclone_exe is not "rclone" and not common.is_file(rclone_exe):
+        if rclone_exe != "rclone" and not common.is_file(rclone_exe):
             #logging.error("rclone executable " + str(rclone_exe) + " not found. Cannot continue!")
             common.print_line('RCLONE.EXE not in PATH. Put it in PATH or modify libsprinkle.conf to point to it.')
             raise Exception("rclone executable " + str(rclone_exe) + " not found")
@@ -113,7 +175,7 @@ class RClone:
         if result['code'] == -20:
             logging.error("rclone executable not found. Please make sure it's in the PATH or in the config file")
             raise Exception("rclone executable not found. Please make sure it's in the PATH or in the config file")
-        if result['error'] is not '':
+        if result['error'] != '':
             logging.error('error getting remotes objects')
             raise Exception('error getting remote object. ' + result['error'])
         remotes = result['out'].splitlines()
@@ -134,7 +196,7 @@ class RClone:
         command_with_args.append(remote + directory)
         result = common.execute(command_with_args, no_error)
         logging.debug('result: ' + str(result)[0:128])
-        if result['error'] is not '':
+        if result['error'] != '':
             if no_error is False:
                 # logging.error('error getting remotes objects')
                 if result['error'].find("directory not found") != -1:
@@ -164,7 +226,7 @@ class RClone:
         command_with_args.append(remote+directory)
         result = common.execute(command_with_args, no_error)
         logging.debug('result: ' + str(result)[0:128])
-        if result['error'] is not '':
+        if result['error'] != '':
             if no_error is False:
                 #logging.error('error getting remotes objects')
                 if result['error'].find("directory not found") != -1:
@@ -178,7 +240,7 @@ class RClone:
         logging.debug('returning ' + str(lsjson)[0:128])
         return lsjson
 
-    def get_about(self, remote):
+    def get_about_json_with_error(self, remote):
         logging.debug('running about for ' + remote)
         command_with_args = []
         command_with_args.append(self._rclone_exe)
@@ -191,14 +253,33 @@ class RClone:
         command_with_args.append("--retries")
         command_with_args.append(self._rclone_retries)
         command_with_args.append(remote)
-        result = common.execute(command_with_args)
+        result = common.execute(command_with_args, True)
         logging.debug('result: ' + str(result))
-        if result['error'] is not '':
-            logging.error('error getting remotes objects')
-            raise Exception('error getting remote object. ' + result['error'])
-        aboutjson = result['out'].splitlines()
+        if result.get('code', 0) != 0 or result.get('error') not in (None, ''):
+            error = result.get('error') or result.get('out') or 'rclone about failed'
+            return None, str(error)
+        if result.get('out') in (None, ''):
+            return None, 'rclone about returned empty output'
+        try:
+            return json.loads(result['out']), None
+        except Exception as exc:
+            return None, 'rclone about returned invalid json: {}'.format(exc.__class__.__name__)
+
+    def get_about_json(self, remote, no_error=False):
+        quota, error = self.get_about_json_with_error(remote)
+        if error is not None:
+            logging.error('error getting remote quota')
+            if no_error:
+                return None
+            raise Exception('error getting remote quota. ' + error)
+        return quota
+
+    def get_about(self, remote):
+        aboutjson = self.get_about_json(remote)
+        if aboutjson is None:
+            return []
         logging.debug('returning ' + str(aboutjson))
-        return aboutjson
+        return json.dumps(aboutjson).splitlines()
 
     def mkdir(self, remote, directory):
         logging.debug('running mkdir for ' + remote + ":" + directory)
@@ -214,7 +295,7 @@ class RClone:
         command_with_args.append(remote + directory)
         result = common.execute(command_with_args)
         logging.debug('result: ' + str(result))
-        if result['error'] is not '':
+        if result['error'] != '':
             logging.error('error getting remotes objects')
             raise Exception('error getting remote object. ' + result['error'])
         out = result['out'].splitlines()
@@ -235,7 +316,7 @@ class RClone:
         command_with_args.append(remote + directory)
         result = common.execute(command_with_args)
         logging.debug('result: ' + str(result))
-        if result['error'] is not '':
+        if result['error'] != '':
             logging.error('error getting remotes objects')
             raise Exception('error getting remote object. ' + result['error'])
         out = result['out'].splitlines()
@@ -247,7 +328,7 @@ class RClone:
         command_with_args = [self._rclone_exe, "version"]
         result = common.execute(command_with_args)
         logging.debug('result: ' + str(result))
-        if result['error'] is not '':
+        if result['error'] != '':
             logging.error('error getting remotes objects')
             raise Exception('error getting remote object. ' + result['error'])
         out = result['out'].splitlines()
@@ -268,7 +349,7 @@ class RClone:
         command_with_args.append(remote + file)
         result = common.execute(command_with_args)
         logging.debug('result: ' + str(result))
-        if result['error'] is not '':
+        if result['error'] != '':
             logging.error('error getting remotes objects')
             raise Exception('error getting remote object. ' + result['error'])
         out = result['out'].splitlines()
@@ -289,7 +370,7 @@ class RClone:
         command_with_args.append(remote + file)
         result = common.execute(command_with_args)
         logging.debug('result: ' + str(result))
-        if result['error'] is not '':
+        if result['error'] != '':
             logging.error('error getting remotes objects')
             raise Exception('error getting remote object. ' + result['error'])
         out = result['out'].splitlines()
@@ -310,7 +391,7 @@ class RClone:
         command_with_args.append(remote + file)
         result = common.execute(command_with_args)
         logging.debug('result: ' + str(result))
-        if result['error'] is not '':
+        if result['error'] != '':
             logging.error('error getting remotes objects')
             raise Exception('error getting remote object. ' + result['error'])
         out = result['out'].splitlines()
@@ -338,7 +419,7 @@ class RClone:
         logging.debug('command args: ' + str(command_with_args))
         result = common.execute(command_with_args, no_error)
         logging.debug('result: ' + str(result))
-        if result['error'] is not '':
+        if result['error'] != '':
             if no_error is False:
                 logging.error('error getting remotes objects')
                 raise Exception('error getting remote object. ' + result['error'])
@@ -366,7 +447,7 @@ class RClone:
         command_with_args.append(dst)
         result = common.execute(command_with_args)
         logging.debug('result: ' + str(result))
-        if result['error'] is not '':
+        if result['error'] != '':
             logging.error('error getting remotes objects')
             raise Exception('error getting remote object. ' + result['error'])
         out = result['out'].splitlines()
@@ -374,63 +455,18 @@ class RClone:
         return out
 
     def get_free(self, remote):
-        logging.debug('running about for ' + remote)
-        command_with_args = []
-        command_with_args.append(self._rclone_exe)
-        command_with_args.append("about")
-        command_with_args.append("--json")
-        if self._config_file is not None:
-            command_with_args.append("--config")
-            command_with_args.append(self._config_file)
-        command_with_args.append("--auto-confirm")
-        command_with_args.append("--retries")
-        command_with_args.append(self._rclone_retries)
-        command_with_args.append(remote)
-        result = common.execute(command_with_args)
-        logging.debug('result: ' + str(result))
-        if result['error'] is not '':
-            logging.error('error getting remotes objects')
-            return 1
-            #raise Exception('error getting remote object. ' + result['error'])
-        aboutjson = result['out']
-        json_obj = json.loads(aboutjson)
-        # simple fix for accounts with errors
-        if "free" in json_obj:
+        json_obj = self.get_about_json(remote, True)
+        if json_obj is not None and "free" in json_obj:
             logging.debug('free ' + str(json_obj['free']))
             return json_obj['free']
-        else:
-            return 1
-#        return json_obj['free']
-
+        return None
 
     def get_size(self, remote):
-        logging.debug('running about for ' + remote)
-        command_with_args = []
-        command_with_args.append(self._rclone_exe)
-        command_with_args.append("about")
-        command_with_args.append("--json")
-        if self._config_file is not None:
-            command_with_args.append("--config")
-            command_with_args.append(self._config_file)
-        command_with_args.append("--auto-confirm")
-        command_with_args.append("--retries")
-        command_with_args.append(self._rclone_retries)
-        command_with_args.append(remote)
-        result = common.execute(command_with_args)
-        logging.debug('result: ' + str(result))
-        if result['error'] is not '':
-            logging.error('error getting remotes objects')
-            #raise Exception('error getting remote object. ' + result['error'])
-            return 1
-        aboutjson = result['out']
-        json_obj = json.loads(aboutjson)
-        # simple fix for accounts with errors
-        if "total" in json_obj:
+        json_obj = self.get_about_json(remote, True)
+        if json_obj is not None and "total" in json_obj:
             logging.debug('total ' + str(json_obj['total']))
             return json_obj['total']
-        else:
-            return 1
-        #return json_obj['total']
+        return None
 
     def sync(self, src, dst, extra_args=[]):
         logging.debug('running sync from ' + src + " to " + dst)
@@ -447,11 +483,9 @@ class RClone:
         command_with_args.append(self._rclone_retries)
         result = common.execute(command_with_args)
         logging.debug('result: ' + str(result))
-        if result['error'] is not '':
+        if result['error'] != '':
             logging.error('error getting remotes objects')
             raise Exception('error getting remote object. ' + result['error'])
         out = result['out'].splitlines()
         logging.debug('returning ' + str(out))
         return out
-
-

--- a/libsprinkle/service_accounts.py
+++ b/libsprinkle/service_accounts.py
@@ -1,0 +1,554 @@
+#!/usr/bin/env python3
+"""
+Service account registry and quota cache.
+"""
+
+import datetime
+import hashlib
+import json
+import os
+import shutil
+import sqlite3
+import stat
+
+
+DEFAULT_DB_PATH = os.path.expanduser("~/.sprinkle/sa-cache.sqlite3")
+DEFAULT_STORE_DIR = os.path.expanduser("~/.sprinkle/service-accounts")
+DEFAULT_CACHE_TTL_HOURS = 72
+DEFAULT_CLEAN_INVALID = "quarantine"
+DEFAULT_REFRESH_MODE = "stale"
+
+REQUIRED_FIELDS = [
+    "type",
+    "project_id",
+    "private_key_id",
+    "private_key",
+    "client_email",
+    "client_id",
+    "token_uri",
+]
+
+
+class ImportResult(object):
+    def __init__(self):
+        self.total = 0
+        self.scanned = 0
+        self.validated = 0
+        self.imported = 0
+        self.duplicates = 0
+        self.invalid = 0
+        self.validation_errors = 0
+        self.quarantined = 0
+        self.deleted = 0
+        self.selected_files = []
+
+
+class ServiceAccountRegistry(object):
+    def __init__(self, db_path=None, store_dir=None, cache_ttl_hours=DEFAULT_CACHE_TTL_HOURS):
+        self.db_path = os.path.abspath(os.path.expanduser(db_path or DEFAULT_DB_PATH))
+        self.store_dir = os.path.abspath(os.path.expanduser(store_dir or DEFAULT_STORE_DIR))
+        self.quarantine_dir = os.path.join(self.store_dir, "quarantine")
+        self.cache_ttl_hours = int(cache_ttl_hours)
+        self._ensure_dirs()
+        self._init_db()
+
+    def _ensure_dirs(self):
+        db_dir = os.path.dirname(self.db_path)
+        if db_dir:
+            if not os.path.isdir(db_dir):
+                os.makedirs(db_dir, mode=0o700, exist_ok=True)
+                os.chmod(db_dir, 0o700)
+        os.makedirs(self.store_dir, mode=0o700, exist_ok=True)
+        os.makedirs(self.quarantine_dir, mode=0o700, exist_ok=True)
+        os.chmod(self.store_dir, 0o700)
+        os.chmod(self.quarantine_dir, 0o700)
+
+    def _connect(self):
+        conn = sqlite3.connect(self.db_path)
+        conn.row_factory = sqlite3.Row
+        return conn
+
+    def _init_db(self):
+        with self._connect() as conn:
+            conn.execute("""
+                CREATE TABLE IF NOT EXISTS accounts (
+                    id INTEGER PRIMARY KEY AUTOINCREMENT,
+                    account_key TEXT,
+                    client_email TEXT,
+                    private_key_id TEXT,
+                    project_id TEXT,
+                    client_id TEXT,
+                    content_hash TEXT NOT NULL,
+                    source_path TEXT,
+                    managed_path TEXT,
+                    remote_name TEXT,
+                    status TEXT NOT NULL,
+                    invalid_reason TEXT,
+                    duplicate_of INTEGER,
+                    imported_at TEXT NOT NULL,
+                    updated_at TEXT NOT NULL
+                )
+            """)
+            conn.execute("""
+                CREATE TABLE IF NOT EXISTS quota_cache (
+                    account_id INTEGER PRIMARY KEY,
+                    total INTEGER,
+                    used INTEGER,
+                    free INTEGER,
+                    trashed INTEGER,
+                    other INTEGER,
+                    objects INTEGER,
+                    last_about_at TEXT,
+                    last_error TEXT,
+                    updated_at TEXT NOT NULL,
+                    FOREIGN KEY(account_id) REFERENCES accounts(id)
+                )
+            """)
+            conn.execute("CREATE INDEX IF NOT EXISTS idx_accounts_status ON accounts(status)")
+            conn.execute("CREATE INDEX IF NOT EXISTS idx_accounts_email ON accounts(client_email)")
+            conn.execute("CREATE INDEX IF NOT EXISTS idx_accounts_key_id ON accounts(private_key_id)")
+            conn.execute("CREATE INDEX IF NOT EXISTS idx_accounts_hash ON accounts(content_hash)")
+            conn.execute("CREATE INDEX IF NOT EXISTS idx_accounts_source ON accounts(source_path)")
+            conn.execute("CREATE INDEX IF NOT EXISTS idx_accounts_remote ON accounts(remote_name)")
+
+    def import_paths(self, paths, clean_invalid=DEFAULT_CLEAN_INVALID, validator=None, progress=None):
+        if clean_invalid not in ("none", "quarantine", "delete"):
+            raise ValueError("invalid service account cleanup mode: {}".format(clean_invalid))
+        result = ImportResult()
+        json_paths = []
+        for path in paths:
+            for json_path in self._iter_json_files(path):
+                json_paths.append(json_path)
+        result.total = len(json_paths)
+        self._emit_progress(progress, {
+            "event": "start",
+            "total": result.total,
+        })
+        for index, json_path in enumerate(json_paths, 1):
+            self._emit_progress(progress, {
+                "event": "file",
+                "index": index,
+                "total": result.total,
+                "path": json_path,
+            })
+            try:
+                result.scanned += 1
+                self._import_file(json_path, clean_invalid, result, validator, progress, index)
+            except Exception as exc:
+                reason = "import error: {}".format(exc)
+                self._record_invalid(json_path, b"", {}, None, reason, clean_invalid, result, self._utcnow())
+                self._emit_progress(progress, {
+                    "event": "status",
+                    "index": index,
+                    "total": result.total,
+                    "path": json_path,
+                    "status": "invalid",
+                    "reason": reason,
+                })
+        result.selected_files = sorted(set(result.selected_files))
+        self._emit_progress(progress, {
+            "event": "complete",
+            "total": result.total,
+            "result": result,
+        })
+        return result
+
+    def _iter_json_files(self, path):
+        path = os.path.abspath(os.path.expanduser(path))
+        if os.path.isfile(path):
+            if path.endswith(".json"):
+                yield path
+            return
+        if not os.path.isdir(path):
+            raise ValueError("service account path not found: {}".format(path))
+        for root, _, files in os.walk(path):
+            for filename in files:
+                if filename.endswith(".json"):
+                    yield os.path.join(root, filename)
+
+    def _import_file(self, path, clean_invalid, result, validator=None, progress=None, index=None):
+        with open(path, "rb") as fp:
+            raw = fp.read()
+        content_hash = hashlib.sha256(raw).hexdigest()
+        now = self._utcnow()
+        try:
+            payload = json.loads(raw.decode("utf-8"))
+            invalid_reason = self.validate_payload(payload)
+        except Exception as exc:
+            payload = {}
+            invalid_reason = "invalid json: {}".format(exc.__class__.__name__)
+
+        if invalid_reason is not None:
+            self._record_invalid(path, raw, payload, content_hash, invalid_reason, clean_invalid, result, now)
+            self._emit_status(progress, index, result.total, path, "invalid", invalid_reason)
+            return
+
+        duplicate = self._find_duplicate(payload, content_hash)
+        account_key = self._account_key(payload, content_hash)
+        if duplicate is not None:
+            result.duplicates += 1
+            self._record_account(
+                account_key=account_key,
+                payload=payload,
+                content_hash=content_hash,
+                source_path=path,
+                managed_path=duplicate["managed_path"],
+                status="duplicate",
+                invalid_reason=None,
+                duplicate_of=duplicate["id"],
+                now=now,
+            )
+            if duplicate["managed_path"]:
+                result.selected_files.append(duplicate["managed_path"])
+            self._emit_status(progress, index, result.total, path, "duplicate", None)
+            return
+
+        quota = None
+        if validator is not None:
+            try:
+                quota, validation_error = validator(path, payload)
+            except Exception as exc:
+                quota = None
+                validation_error = "validation error: {}".format(exc)
+            if validation_error is not None:
+                result.validation_errors += 1
+                self._record_invalid(
+                    path,
+                    raw,
+                    payload,
+                    content_hash,
+                    validation_error,
+                    clean_invalid,
+                    result,
+                    now,
+                    account_key,
+                )
+                self._emit_status(progress, index, result.total, path, "invalid", validation_error)
+                return
+            result.validated += 1
+
+        managed_path = self._managed_path(account_key)
+        shutil.copyfile(path, managed_path)
+        os.chmod(managed_path, stat.S_IRUSR | stat.S_IWUSR)
+        account_id = self._record_account(
+            account_key=account_key,
+            payload=payload,
+            content_hash=content_hash,
+            source_path=path,
+            managed_path=managed_path,
+            status="active",
+            invalid_reason=None,
+            duplicate_of=None,
+            now=now,
+        )
+        if quota is not None:
+            self.update_quota(account_id, quota, None)
+        result.imported += 1
+        result.selected_files.append(managed_path)
+        self._emit_status(progress, index, result.total, path, "imported", None)
+        return account_id
+
+    def _record_invalid(
+            self,
+            path,
+            raw,
+            payload,
+            content_hash,
+            invalid_reason,
+            clean_invalid,
+            result,
+            now,
+            account_key=None):
+        if content_hash is None:
+            content_hash = hashlib.sha256(raw).hexdigest()
+        result.invalid += 1
+        managed_path = None
+        if clean_invalid == "quarantine":
+            managed_path = self._quarantine(path, content_hash, raw)
+            result.quarantined += 1
+        elif clean_invalid == "delete":
+            os.remove(path)
+            result.deleted += 1
+        self._record_account(
+            account_key=account_key,
+            payload=payload,
+            content_hash=content_hash,
+            source_path=path,
+            managed_path=managed_path,
+            status="invalid",
+            invalid_reason=invalid_reason,
+            duplicate_of=None,
+            now=now,
+        )
+
+    def _emit_status(self, progress, index, total, path, status, reason):
+        self._emit_progress(progress, {
+            "event": "status",
+            "index": index,
+            "total": total,
+            "path": path,
+            "status": status,
+            "reason": reason,
+        })
+
+    def _emit_progress(self, progress, event):
+        if progress is not None:
+            progress(event)
+
+    def validate_payload(self, payload):
+        if not isinstance(payload, dict):
+            return "json root is not an object"
+        missing = [field for field in REQUIRED_FIELDS if not payload.get(field)]
+        if missing:
+            return "missing required fields: {}".format(",".join(missing))
+        if payload.get("type") != "service_account":
+            return "type is not service_account"
+        private_key = payload.get("private_key", "")
+        if "BEGIN PRIVATE KEY" not in private_key:
+            return "private_key is not a private key"
+        return None
+
+    def _find_duplicate(self, payload, content_hash):
+        with self._connect() as conn:
+            client_email = payload.get("client_email")
+            if client_email:
+                row = conn.execute(
+                    "SELECT * FROM accounts WHERE status='active' AND client_email=? ORDER BY id LIMIT 1",
+                    (client_email,),
+                ).fetchone()
+                if row is not None:
+                    return row
+            private_key_id = payload.get("private_key_id")
+            if private_key_id:
+                row = conn.execute(
+                    "SELECT * FROM accounts WHERE status='active' AND private_key_id=? ORDER BY id LIMIT 1",
+                    (private_key_id,),
+                ).fetchone()
+                if row is not None:
+                    return row
+            row = conn.execute(
+                "SELECT * FROM accounts WHERE status='active' AND content_hash=? ORDER BY id LIMIT 1",
+                (content_hash,),
+            ).fetchone()
+            return row
+
+    def _record_account(
+            self,
+            account_key,
+            payload,
+            content_hash,
+            source_path,
+            managed_path,
+            status,
+            invalid_reason,
+            duplicate_of,
+            now):
+        with self._connect() as conn:
+            cursor = conn.execute(
+                """
+                INSERT INTO accounts (
+                    account_key, client_email, private_key_id, project_id, client_id,
+                    content_hash, source_path, managed_path, status, invalid_reason,
+                    duplicate_of, imported_at, updated_at
+                ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+                """,
+                (
+                    account_key,
+                    payload.get("client_email"),
+                    payload.get("private_key_id"),
+                    payload.get("project_id"),
+                    payload.get("client_id"),
+                    content_hash,
+                    source_path,
+                    managed_path,
+                    status,
+                    invalid_reason,
+                    duplicate_of,
+                    now,
+                    now,
+                ),
+            )
+            return cursor.lastrowid
+
+    def _account_key(self, payload, content_hash):
+        if payload.get("client_email"):
+            return "email:" + payload["client_email"]
+        if payload.get("private_key_id"):
+            return "key:" + payload["private_key_id"]
+        return "hash:" + content_hash
+
+    def _managed_path(self, account_key):
+        digest = hashlib.sha256(account_key.encode("utf-8")).hexdigest()
+        return os.path.join(self.store_dir, "sa-{}.json".format(digest[:24]))
+
+    def _quarantine(self, source_path, content_hash, raw):
+        filename = "invalid-{}-{}".format(content_hash[:24], os.path.basename(source_path))
+        path = os.path.join(self.quarantine_dir, filename)
+        with open(path, "wb") as fp:
+            fp.write(raw)
+        os.chmod(path, stat.S_IRUSR | stat.S_IWUSR)
+        return path
+
+    def active_accounts(self, limit=None):
+        sql = "SELECT * FROM accounts WHERE status='active' ORDER BY client_email, id"
+        params = ()
+        if limit is not None:
+            sql += " LIMIT ?"
+            params = (int(limit),)
+        with self._connect() as conn:
+            return conn.execute(sql, params).fetchall()
+
+    def all_account_stats(self):
+        with self._connect() as conn:
+            return conn.execute("""
+                SELECT
+                    a.*,
+                    q.total, q.used, q.free, q.trashed, q.other, q.objects,
+                    q.last_about_at, q.last_error
+                FROM accounts a
+                LEFT JOIN quota_cache q ON q.account_id = a.id
+                ORDER BY a.status, a.client_email, a.id
+            """).fetchall()
+
+    def summary_counts(self):
+        with self._connect() as conn:
+            rows = conn.execute("SELECT status, COUNT(*) AS count FROM accounts GROUP BY status").fetchall()
+        return dict((row["status"], row["count"]) for row in rows)
+
+    def assign_remote_names(self, entries):
+        now = self._utcnow()
+        with self._connect() as conn:
+            for entry in entries:
+                managed_path = os.path.abspath(entry["path"])
+                remote = entry["remote"].rstrip(":")
+                conn.execute(
+                    """
+                    UPDATE accounts
+                    SET remote_name=?, updated_at=?
+                    WHERE status='active' AND managed_path=?
+                    """,
+                    (remote, now, managed_path),
+                )
+
+    def quota_by_remote(self, remote):
+        remote_name = remote.rstrip(":")
+        with self._connect() as conn:
+            return conn.execute("""
+                SELECT
+                    a.id AS account_id,
+                    a.remote_name,
+                    q.total, q.used, q.free, q.trashed, q.other, q.objects,
+                    q.last_about_at, q.last_error
+                FROM accounts a
+                LEFT JOIN quota_cache q ON q.account_id = a.id
+                WHERE a.status='active' AND a.remote_name=?
+                ORDER BY a.id
+                LIMIT 1
+            """, (remote_name,)).fetchone()
+
+    def quota_by_account_id(self, account_id):
+        with self._connect() as conn:
+            return conn.execute(
+                "SELECT * FROM quota_cache WHERE account_id=?",
+                (account_id,),
+            ).fetchone()
+
+    def should_refresh(self, quota_row, mode):
+        if mode == "none":
+            return False
+        if mode == "all":
+            return True
+        if quota_row is None or quota_row["last_about_at"] is None:
+            return mode in ("missing", "stale")
+        if mode == "missing":
+            return False
+        if mode == "stale":
+            return self.is_stale(quota_row["last_about_at"])
+        return False
+
+    def is_stale(self, last_about_at):
+        if last_about_at is None:
+            return True
+        last = datetime.datetime.strptime(last_about_at, "%Y-%m-%dT%H:%M:%SZ")
+        age = datetime.datetime.utcnow() - last
+        return age.total_seconds() > self.cache_ttl_hours * 3600
+
+    def update_quota_for_remote(self, remote, quota, error=None):
+        row = self.quota_by_remote(remote)
+        if row is None:
+            return
+        self.update_quota(row["account_id"], quota, error)
+
+    def update_quota(self, account_id, quota, error=None):
+        now = self._utcnow()
+        if error is not None:
+            with self._connect() as conn:
+                existing = conn.execute(
+                    "SELECT account_id FROM quota_cache WHERE account_id=?",
+                    (account_id,),
+                ).fetchone()
+                if existing is None:
+                    conn.execute("""
+                        INSERT INTO quota_cache (
+                            account_id, last_about_at, last_error, updated_at
+                        ) VALUES (?, ?, ?, ?)
+                    """, (account_id, None, error, now))
+                else:
+                    conn.execute("""
+                        UPDATE quota_cache
+                        SET last_error=?, updated_at=?
+                        WHERE account_id=?
+                    """, (error, now, account_id))
+            return
+        quota = quota or {}
+        last_about_at = now if error is None else None
+        with self._connect() as conn:
+            conn.execute("""
+                INSERT INTO quota_cache (
+                    account_id, total, used, free, trashed, other, objects,
+                    last_about_at, last_error, updated_at
+                ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+                ON CONFLICT(account_id) DO UPDATE SET
+                    total=excluded.total,
+                    used=excluded.used,
+                    free=excluded.free,
+                    trashed=excluded.trashed,
+                    other=excluded.other,
+                    objects=excluded.objects,
+                    last_about_at=excluded.last_about_at,
+                    last_error=excluded.last_error,
+                    updated_at=excluded.updated_at
+            """, (
+                account_id,
+                quota.get("total"),
+                quota.get("used"),
+                quota.get("free"),
+                quota.get("trashed"),
+                quota.get("other"),
+                quota.get("objects"),
+                last_about_at,
+                error,
+                now,
+            ))
+
+    def adjust_quota_for_remote(self, remote, byte_delta):
+        row = self.quota_by_remote(remote)
+        if row is None:
+            return
+        now = self._utcnow()
+        free = row["free"]
+        used = row["used"]
+        if free is not None:
+            free = max(0, free - int(byte_delta))
+        if used is not None:
+            used = used + int(byte_delta)
+        with self._connect() as conn:
+            conn.execute("""
+                UPDATE quota_cache
+                SET free=?, used=?, updated_at=?
+                WHERE account_id=?
+            """, (free, used, now, row["account_id"]))
+
+    @staticmethod
+    def _utcnow():
+        return datetime.datetime.utcnow().strftime("%Y-%m-%dT%H:%M:%SZ")

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,49 @@
+[build-system]
+requires = ["setuptools>=61", "wheel"]
+build-backend = "setuptools.build_meta"
+
+[project]
+name = "sprinkle-py"
+version = "1.0.0"
+description = "Sprinkle is a volume clustering utility based on RClone."
+readme = "README.md"
+requires-python = ">=3.6"
+license = { text = "GPLv3" }
+authors = [
+    { name = "Michael Montuori", email = "michael.montuori@gmail.com" },
+]
+keywords = ["sprinkle", "cloud", "backup", "restore", "rclone"]
+classifiers = [
+    "Development Status :: 5 - Production/Stable",
+    "Intended Audience :: Developers",
+    "Natural Language :: English",
+    "Programming Language :: Python :: 3",
+    "License :: OSI Approved :: GNU General Public License v3 (GPLv3)",
+]
+dependencies = [
+    "daemons>=1.3.0",
+    "filelock>=3.0.10",
+    "progress>=1.4",
+]
+
+[project.urls]
+Homepage = "https://gitlab.com/mmontuori/sprinkle"
+Source = "https://gitlab.com/mmontuori/sprinkle"
+
+[project.optional-dependencies]
+dev = [
+    "build>=1.0",
+    "pytest>=7.0",
+    "twine>=4.0",
+]
+
+[tool.setuptools]
+packages = ["libsprinkle"]
+py-modules = ["sprinkle"]
+script-files = ["sprinkle.py"]
+include-package-data = true
+zip-safe = true
+
+[tool.pytest.ini_options]
+testpaths = ["tests"]
+python_files = ["test_*.py"]

--- a/setup.py
+++ b/setup.py
@@ -1,48 +1,11 @@
-#!/usr/bin/env python
-"""
-setup.py PuPI setup project file
-"""
-__author__ = "Michael Montuori [michael.montuori@gmail.com]"
-__copyright__ = "Copyright 2017 Michael Montuori. All rights reserved."
-__credits__ = []
-__license__ = "GPLv3"
-__version__ = "1.0"
-__revision__ = "0"
+#!/usr/bin/env python3
+"""Compatibility shim for setuptools.
 
-import os
+Project metadata lives in pyproject.toml. Keeping this file lets legacy
+commands such as ``python3 setup.py sdist`` continue to work.
+"""
+
 from setuptools import setup
-from setuptools import find_packages
-import sprinkle
 
-with open('README.md', 'r') as fh:
-    long_description = fh.read()
 
-this = os.path.dirname(os.path.realpath(__file__))
-
-def read(name):
-    with open(os.path.join(this, name)) as f:
-        return f.read()
-
-setup(
-    name='sprinkle-py',
-    version=sprinkle.__version__+'.'+sprinkle.__revision__,
-    #packages=find_packages(exclude=['contrib', 'docs', 'tests']),
-    packages=['libsprinkle'],
-    install_requires=read('requirements.txt'),
-    url='https://gitlab.com/mmontuori/sprinkle',
-    license='GPLv3',
-    include_package_data=True,
-    author='mmontuori',
-    author_email='michael.montuori@gmail.com',
-    description='Sprinkle is a volume clustering utility based on [RClone](https://rclone.org).',
-    long_description=long_description,
-    keywords='sprinkle cloud backup restore',
-    zip_safe=True,
-    long_description_content_type="text/markdown",
-    classifiers=[
-        'Development Status :: 5 - Production/Stable',
-        'Intended Audience :: Developers',
-        'Natural Language :: English'
-    ],
-    scripts=['sprinkle.py']
-)
+setup()

--- a/sprinkle.conf
+++ b/sprinkle.conf
@@ -22,6 +22,26 @@
 # rclone configuration file location (use this to override the default config file)
 # rclone_config=
 
+# service account registry database and managed JSON store
+# service account JSON files contain secrets; do not commit the managed store
+# Equivalent CLI defaults can be stored here:
+# --rclone-sa-count 5 --drive-id XXXXX -d --rclone-sa-dir /etc/rclone/sa
+# debug=true
+# rclone_sa_count=5
+# drive_id=XXXXX
+# rclone_sa_dir=/etc/rclone/sa
+# sa_db=~/.sprinkle/sa-cache.sqlite3
+# sa_store=~/.sprinkle/service-accounts
+# sa_cache_ttl_hours=72
+# sa_refresh=stale
+# sa_clean_invalid=quarantine
+# sa_group_size=50
+
+# large-file upload selection keeps enough headroom on small Google Drive accounts
+# large_file_threshold_bytes=1073741824
+# large_file_min_free_bytes=536870912
+# large_file_min_free_percent=5
+
 # temporaty directory available to sprinkle
 # NOT IMPLEMENTED YET
 # rclone_workdir={workdir}
@@ -97,4 +117,3 @@ delete_files=false
 # smtp_port=587
 # smtp_user=user@mail.com
 # smtp_password=password
-

--- a/sprinkle.py
+++ b/sprinkle.py
@@ -14,6 +14,7 @@ from libsprinkle import clsync
 from libsprinkle import rclone
 from libsprinkle import config
 from libsprinkle import common
+from libsprinkle import service_accounts
 from libsprinkle import smtp_email
 from libsprinkle import sprinkle_daemon
 import logging
@@ -32,6 +33,10 @@ except:
 lock = FileLock("sprinkle.lock", timeout=1)
 
 __drive_id = None
+
+def default_config_path():
+    return os.path.join(os.path.expanduser("~"), ".sprinkle", "sprinkle.conf")
+
 
 def warranty():
     """
@@ -93,6 +98,12 @@ OPTIONS:
     --rclone-sa-dir {dir}        build rclone config from service accounts
     --rclone-sa-count {num}      limit number of service accounts used
     --drive-id {id}              Google Drive folder ID for rclone config
+    --sa-db {file}               service account registry database
+    --sa-store {dir}             managed service account store
+    --sa-cache-ttl-hours {num}   hours before cached SA quota is stale (default:72)
+    --sa-refresh {mode}          SA quota refresh [missing|stale|all|none] (default:stale)
+    --sa-clean-invalid {mode}    invalid SA cleanup [none|quarantine|delete] (default:quarantine)
+    --sa-group-size {num}        preferred SA grouping size for generated operator configs
     --rclone-exe {rclone_exe}    rclone executable (default:rclone)
     --rclone-move                use 'rclone move' instead of 'rclone copy' (default:false)
     --restore-duplicates         restore files if duplicates are found (default:false)
@@ -108,11 +119,13 @@ def usage_commands():
     """
 COMMANDS:
     backup                       backup files to clustered drives
-    config                       configure rclone to access volumes
+    config                       create ~/.sprinkle/sprinkle.conf
     help                         displays the help fot the specific command
     ls                           list files
     lsmd5                        list md5 of files
     stats                        display volume statistics
+    sa-import                    import Google Drive service account files
+    sa-stats                     display imported service account statistics
     restore                      restore files from clustered drives
     removedups                   removes duplicate files
     """
@@ -132,6 +145,7 @@ DESCRIPTION:
     Sprinkle uses the excellent [RClone](https://rclone.org) software for cloud volume access.
 
 EXAMPLES:
+    sprinkle.py config
     sprinkle.py ls /backup
     sprinkle.py backup /dir_to_backup
     sprinkle.py restore /backup /opt/restore_dir
@@ -151,20 +165,21 @@ EXAMPLES:
 def usage_config():
     """
 NAME:
-    sprinkle config - configure sprinkle/rclone
+    sprinkle config - create a Sprinkle configuration file
 
 SYNOPSIS:
     sprinkle.py [options] config
 
 DESCRIPTION:
-    Configure sprinkle/rclone to communicate with remote volumes. This process might enable API access and may
-    require authorization before sprinkle/rclone can access the drives. For config documentation refer to rclone
-    documentation at https://rclone.org/docs/.
+    Interactively writes ~/.sprinkle/sprinkle.conf with the common Sprinkle defaults,
+    including rclone_move, delete_files, and Google Drive service account cache defaults.
+    Use -c/--conf with this command to write a different config path.
 
 EXAMPLES:
     sprinkle.py config
+    sprinkle.py -c /tmp/sprinkle.conf config
     """
-    print(usage_ls.__doc__)
+    print(usage_config.__doc__)
     print(usage_options.__doc__)
     print(copyrights.__doc__)
     print(credits.__doc__)
@@ -336,6 +351,52 @@ EXAMPLES:
     print(credits.__doc__)
 
 
+def usage_sa_import():
+    """
+NAME:
+    sprinkle sa-import - import Google Drive service account files
+
+SYNOPSIS:
+    sprinkle.py [options] sa-import {path...}
+
+DESCRIPTION:
+    Recursively imports valid service account JSON files into Sprinkle's managed store.
+    Duplicates are recorded but not copied again. New accounts are validated with
+    rclone about --json during import. Invalid accounts and unknown quota results are
+    quarantined by default.
+
+EXAMPLES:
+    sprinkle.py --drive-id XXXXX sa-import /Users/user/workspace/svcacc
+    """
+    print(usage_sa_import.__doc__)
+    print(usage_options.__doc__)
+    print(copyrights.__doc__)
+    print(credits.__doc__)
+
+
+def usage_sa_stats():
+    """
+NAME:
+    sprinkle sa-stats - display imported service account statistics
+
+SYNOPSIS:
+    sprinkle.py [options] sa-stats
+
+DESCRIPTION:
+    Shows imported service accounts and cached quota data. By default this command refreshes
+    stale cache entries with rclone about --json.
+
+EXAMPLES:
+    sprinkle.py --drive-id XXXXX sa-stats
+    sprinkle.py --sa-refresh=none sa-stats
+    sprinkle.py --sa-cache-ttl-hours=72 --sa-refresh=stale sa-stats
+    """
+    print(usage_sa_stats.__doc__)
+    print(usage_options.__doc__)
+    print(copyrights.__doc__)
+    print(credits.__doc__)
+
+
 def usage_removedups():
     """
 NAME:
@@ -427,6 +488,14 @@ def read_args(argv):
     global __daemon_interval
     global __daemon_pidfile
     global __ls_stop_first
+    global __sa_db
+    global __sa_store
+    global __sa_cache_ttl_hours
+    global __sa_refresh
+    global __sa_clean_invalid
+    global __sa_group_size
+    global __rclone_sa_dir
+    global __rclone_sa_count
 
     __configfile = None
     __cmd_debug = None
@@ -461,9 +530,14 @@ def read_args(argv):
     __daemon_interval = None
     __daemon_pidfile = None
     __ls_stop_first = None
-
-    rclone_sa_dir = None
-    rclone_sa_count = None
+    __sa_db = None
+    __sa_store = None
+    __sa_cache_ttl_hours = None
+    __sa_refresh = None
+    __sa_clean_invalid = None
+    __sa_group_size = None
+    __rclone_sa_dir = None
+    __rclone_sa_count = None
 
     try:
         opts, args = getopt.getopt(argv, "dvhc:s:",
@@ -478,6 +552,12 @@ def read_args(argv):
                                     "rclone-sa-dir=",
                                     "rclone-sa-count=",
                                     "drive-id=",
+                                    "sa-db=",
+                                    "sa-store=",
+                                    "sa-cache-ttl-hours=",
+                                    "sa-refresh=",
+                                    "sa-clean-invalid=",
+                                    "sa-group-size=",
                                     "stats=",
                                     "display-unit=",
                                     "rclone-retries=",
@@ -529,12 +609,28 @@ def read_args(argv):
         elif opt in ("--rclone-conf"):
             __rclone_conf = arg
         elif opt in ("--rclone-sa-dir"):
-            rclone_sa_dir = arg
+            __rclone_sa_dir = arg
         elif opt in ("--rclone-sa-count"):
-            rclone_sa_count = int(arg)
+            __rclone_sa_count = int(arg)
         elif opt in ("--drive-id"):
             __drive_id = arg
             __ls_stop_first = True
+        elif opt in ("--sa-db"):
+            __sa_db = arg
+        elif opt in ("--sa-store"):
+            __sa_store = arg
+        elif opt in ("--sa-cache-ttl-hours"):
+            __sa_cache_ttl_hours = int(arg)
+        elif opt in ("--sa-refresh"):
+            if arg not in ("missing", "stale", "all", "none"):
+                raise Exception("--sa-refresh must be one of missing, stale, all, none")
+            __sa_refresh = arg
+        elif opt in ("--sa-clean-invalid"):
+            if arg not in ("none", "quarantine", "delete"):
+                raise Exception("--sa-clean-invalid must be one of none, quarantine, delete")
+            __sa_clean_invalid = arg
+        elif opt in ("--sa-group-size"):
+            __sa_group_size = int(arg)
         elif opt in ("--display-unit"):
             if arg != 'G' and arg != 'M' and arg != 'K' and arg != 'B':
                 logging.error('invalid UNIT ' + arg + ', only [G|M|K|B] accepted')
@@ -589,15 +685,10 @@ def read_args(argv):
         elif opt in ("--daemon-pidfile"):
             __daemon_pidfile = arg
 
-    if rclone_sa_dir is not None:
-        if __drive_id is None:
-            raise Exception("--drive-id option is required when using --rclone-sa-dir")
-        fd, tmp_conf = tempfile.mkstemp(prefix="rclone-", suffix=".conf")
-        os.close(fd)
-        rclone.generate_rclone_config(
-            rclone_sa_dir, tmp_conf, __drive_id, max_accounts=rclone_sa_count
-        )
-        __rclone_conf = tmp_conf
+    if __configfile is None:
+        candidate_config = default_config_path()
+        if os.path.isfile(candidate_config):
+            __configfile = candidate_config
 
     if len(args) < 1 and __check_prereq is None:
         usage()
@@ -624,6 +715,9 @@ def configure(config_file):
         "compare_method": "size",
         "display_unit": "G",
         "rclone_retries": '1',
+        "drive_id": None,
+        "rclone_sa_dir": None,
+        "rclone_sa_count": None,
         "log_file": None,
         "single_instance": False,
         "ls_stop_first": False,
@@ -631,7 +725,16 @@ def configure(config_file):
         "daemon_type": 'interval',
         "daemon_mode": False,
         "daemon_interval": 60,
-        "daemon_pidfile": '/var/run/sprinkle.pid'
+        "daemon_pidfile": '/var/run/sprinkle.pid',
+        "sa_db": service_accounts.DEFAULT_DB_PATH,
+        "sa_store": service_accounts.DEFAULT_STORE_DIR,
+        "sa_cache_ttl_hours": service_accounts.DEFAULT_CACHE_TTL_HOURS,
+        "sa_refresh": service_accounts.DEFAULT_REFRESH_MODE,
+        "sa_clean_invalid": service_accounts.DEFAULT_CLEAN_INVALID,
+        "sa_group_size": 50,
+        "large_file_threshold_bytes": clsync.DEFAULT_LARGE_FILE_THRESHOLD_BYTES,
+        "large_file_min_free_bytes": clsync.DEFAULT_LARGE_FILE_MIN_FREE_BYTES,
+        "large_file_min_free_percent": clsync.DEFAULT_LARGE_FILE_MIN_FREE_PERCENT
     }
 
     if config_file is not None:
@@ -644,7 +747,10 @@ def configure(config_file):
         if field not in __config:
             __config[field] = _default_values[field]
 
+    normalize_config_types(__config)
+
     if __cmd_debug is True:
+        __config['debug'] = True
         init_logging(True, __daemon_mode)
     elif 'debug' in __config:
         init_logging(__config['debug'], __daemon_mode)
@@ -663,6 +769,12 @@ def configure(config_file):
 
     if __drive_id is not None:
         __config['drive_id'] = __drive_id
+
+    if __rclone_sa_dir is not None:
+        __config['rclone_sa_dir'] = __rclone_sa_dir
+
+    if __rclone_sa_count is not None:
+        __config['rclone_sa_count'] = __rclone_sa_count
 
     if __rclone_retries is not None:
         __config['rclone_retries'] = str(__rclone_retries)
@@ -737,6 +849,62 @@ def configure(config_file):
     if __daemon_pidfile is not None:
         __config['daemon_pidfile'] = __daemon_pidfile
 
+    if __sa_db is not None:
+        __config['sa_db'] = __sa_db
+
+    if __sa_store is not None:
+        __config['sa_store'] = __sa_store
+
+    if __sa_cache_ttl_hours is not None:
+        __config['sa_cache_ttl_hours'] = __sa_cache_ttl_hours
+
+    if __sa_refresh is not None:
+        __config['sa_refresh'] = __sa_refresh
+
+    if __sa_clean_invalid is not None:
+        __config['sa_clean_invalid'] = __sa_clean_invalid
+
+    if __sa_group_size is not None:
+        __config['sa_group_size'] = __sa_group_size
+
+
+def normalize_config_types(config_values):
+    bool_fields = (
+        'debug',
+        'dry_run',
+        'show_progress',
+        'delete_files',
+        'rclone_move',
+        'restore_duplicates',
+        'smtp_enable',
+        'no_cache',
+        'single_instance',
+        'ls_stop_first',
+        'check_prereq',
+        'daemon_mode',
+    )
+    int_fields = (
+        'daemon_interval',
+        'sa_cache_ttl_hours',
+        'sa_group_size',
+        'rclone_sa_count',
+        'large_file_threshold_bytes',
+        'large_file_min_free_bytes',
+        'large_file_min_free_percent',
+    )
+    for field in bool_fields:
+        if field in config_values:
+            config_values[field] = _parse_bool(config_values[field])
+    for field in int_fields:
+        if field in config_values and config_values[field] not in (None, ''):
+            config_values[field] = int(config_values[field])
+
+
+def _parse_bool(value):
+    if isinstance(value, bool):
+        return value
+    return str(value).strip().lower() in ('true', '1', 'yes', 'y', 'ja', 'j')
+
 
 def verify_configuration():
     logging.debug('verifying configuration ' + str(__config))
@@ -761,6 +929,56 @@ def verify_configuration():
     if __daemon_mode is True and os.access(os.path.dirname(__config['daemon_pidfile']), os.W_OK) is not True:
         logging.warning('cannot write to pidfile "' + __config['daemon_pidfile'] + '" switching to /tmp/sprinkle.pid')
         __config['daemon_pidfile'] = '/tmp/sprinkle.pid'
+
+
+def prepare_rclone_sa_config():
+    global __rclone_conf
+    rclone_sa_dir = __config.get('rclone_sa_dir')
+    if rclone_sa_dir in (None, ''):
+        return
+    if __rclone_conf is not None and globals().get('__rclone_sa_dir') is None:
+        return
+    drive_id = __config.get('drive_id')
+    if drive_id in (None, ''):
+        raise Exception("--drive-id option or drive_id config value is required when using rclone_sa_dir")
+    fd, tmp_conf = tempfile.mkstemp(prefix="rclone-", suffix=".conf")
+    os.close(fd)
+    registry = service_accounts.ServiceAccountRegistry(
+        __config.get('sa_db'),
+        __config.get('sa_store'),
+        __config.get('sa_cache_ttl_hours', service_accounts.DEFAULT_CACHE_TTL_HOURS),
+    )
+    import_result = registry.import_paths(
+        [rclone_sa_dir],
+        __config.get('sa_clean_invalid', service_accounts.DEFAULT_CLEAN_INVALID),
+    )
+    if len(import_result.selected_files) == 0:
+        raise Exception("no valid service accounts found in " + rclone_sa_dir)
+    config_text, entries = rclone.generate_rclone_config_from_files(
+        import_result.selected_files,
+        tmp_conf,
+        drive_id,
+        max_accounts=_optional_int(__config.get('rclone_sa_count')),
+        return_entries=True,
+        shuffle=False,
+    )
+    registry.assign_remote_names(entries)
+    __rclone_conf = tmp_conf
+    __config['rclone_config'] = tmp_conf
+
+
+def command_needs_rclone_config():
+    if __check_prereq is not None and __check_prereq is True:
+        return True
+    if len(__args) < 1:
+        return False
+    return __args[0] in ('ls', 'lsmd5', 'backup', 'restore', 'stats', 'removedups', 'find')
+
+
+def _optional_int(value):
+    if value in (None, ''):
+        return None
+    return int(value)
 
 
 def load_exclusion_file(exclude_file):
@@ -793,6 +1011,161 @@ def init_logging(debug, daemon_mode=False):
                                 level=logging.INFO,
                                 filename=__log_file)
         logging.getLogger('sprinkle').setLevel(logging.INFO)
+
+
+def config_command(prompt_func=input, output_path=None):
+    target = output_path or default_config_path()
+    common.print_line('creating Sprinkle configuration at ' + target)
+    if os.path.exists(target):
+        overwrite = _prompt_bool(prompt_func, 'Overwrite existing config', False)
+        if not overwrite:
+            common.print_line('configuration not changed')
+            return target
+
+    rclone_move = _prompt_bool(prompt_func, 'rclone_move: move files instead of copying them', True)
+    delete_files = _prompt_bool(prompt_func, 'delete_files: delete files after 1-way sync', False)
+    debug = _prompt_bool(prompt_func, 'debug output (-d)', True)
+    rclone_sa_count = _prompt_text(prompt_func, 'rclone_sa_count', '5')
+    drive_id = _prompt_text(prompt_func, 'drive_id', 'XXXXX')
+    rclone_sa_dir = _prompt_text(prompt_func, 'rclone_sa_dir', '/etc/rclone/sa')
+    sa_cache_ttl_hours = _prompt_int(
+        prompt_func,
+        'sa_cache_ttl_hours',
+        service_accounts.DEFAULT_CACHE_TTL_HOURS,
+    )
+    sa_refresh = _prompt_choice(
+        prompt_func,
+        'sa_refresh',
+        service_accounts.DEFAULT_REFRESH_MODE,
+        ('missing', 'stale', 'all', 'none'),
+    )
+    sa_clean_invalid = _prompt_choice(
+        prompt_func,
+        'sa_clean_invalid',
+        service_accounts.DEFAULT_CLEAN_INVALID,
+        ('none', 'quarantine', 'delete'),
+    )
+
+    content = _build_config_text(
+        rclone_move,
+        delete_files,
+        debug,
+        rclone_sa_count,
+        drive_id,
+        rclone_sa_dir,
+        sa_cache_ttl_hours,
+        sa_refresh,
+        sa_clean_invalid,
+    )
+    parent = os.path.dirname(target)
+    if parent:
+        os.makedirs(parent, exist_ok=True)
+    with open(target, 'w') as fp:
+        fp.write(content)
+    common.print_line('wrote ' + target)
+    return target
+
+
+def _prompt_bool(prompt_func, label, default):
+    default_text = 'Y/n' if default else 'y/N'
+    answer = prompt_func(label + ' [' + default_text + ']: ').strip().lower()
+    if answer == '':
+        return default
+    return answer in ('y', 'yes', 'true', '1', 'j', 'ja')
+
+
+def _prompt_text(prompt_func, label, default):
+    answer = prompt_func(label + ' [' + str(default) + ']: ').strip()
+    if answer == '':
+        return str(default)
+    return answer
+
+
+def _prompt_int(prompt_func, label, default):
+    while True:
+        answer = _prompt_text(prompt_func, label, default)
+        try:
+            return str(int(answer))
+        except ValueError:
+            common.print_line(label + ' must be an integer')
+
+
+def _prompt_choice(prompt_func, label, default, choices):
+    while True:
+        answer = _prompt_text(prompt_func, label + ' {' + '|'.join(choices) + '}', default)
+        if answer in choices:
+            return answer
+        common.print_line(label + ' must be one of ' + ', '.join(choices))
+
+
+def _bool_text(value):
+    return 'true' if value else 'false'
+
+
+def _build_config_text(
+        rclone_move,
+        delete_files,
+        debug,
+        rclone_sa_count,
+        drive_id,
+        rclone_sa_dir,
+        sa_cache_ttl_hours,
+        sa_refresh,
+        sa_clean_invalid):
+    return """## SPRINKLE CONFIGURATION
+## Generated by: sprinkle.py config
+
+# run sprinkle in debug mode. Equivalent to command line -d
+debug={debug}
+
+# rclone_move: move files instead of copying them
+# rclone_move=false (copy files and keep sources) (default)
+rclone_move={rclone_move}
+
+# delete_files: delete files after 1-way sync
+# delete_files=false (leave files not locally present on remote drives)
+# delete_files=true (delete files not locally present from remote drives) (default)
+delete_files={delete_files}
+
+# Google Drive service account defaults.
+# Equivalent command line:
+# --rclone-sa-count {rclone_sa_count} --drive-id {drive_id} -d --rclone-sa-dir {rclone_sa_dir}
+rclone_sa_count={rclone_sa_count}
+drive_id={drive_id}
+rclone_sa_dir={rclone_sa_dir}
+
+# service account registry database and managed JSON store
+sa_db=~/.sprinkle/sa-cache.sqlite3
+sa_store=~/.sprinkle/service-accounts
+sa_cache_ttl_hours={sa_cache_ttl_hours}
+sa_refresh={sa_refresh}
+sa_clean_invalid={sa_clean_invalid}
+sa_group_size=50
+
+# Large-file upload selection keeps enough headroom on small Google Drive accounts.
+# Defaults require an extra 512 MiB or 5%, whichever is larger, for files >= 1 GiB.
+large_file_threshold_bytes={large_file_threshold_bytes}
+large_file_min_free_bytes={large_file_min_free_bytes}
+large_file_min_free_percent={large_file_min_free_percent}
+
+display_unit=G
+distribution_type=mas
+compare_method=size
+rclone_retries=1
+""".format(
+        debug=_bool_text(debug),
+        rclone_move=_bool_text(rclone_move),
+        delete_files=_bool_text(delete_files),
+        rclone_sa_count=rclone_sa_count,
+        drive_id=drive_id,
+        rclone_sa_dir=rclone_sa_dir,
+        sa_cache_ttl_hours=sa_cache_ttl_hours,
+        sa_refresh=sa_refresh,
+        sa_clean_invalid=sa_clean_invalid,
+        large_file_threshold_bytes=clsync.DEFAULT_LARGE_FILE_THRESHOLD_BYTES,
+        large_file_min_free_bytes=clsync.DEFAULT_LARGE_FILE_MIN_FREE_BYTES,
+        large_file_min_free_percent=clsync.DEFAULT_LARGE_FILE_MIN_FREE_PERCENT,
+    )
 
 
 def ls():
@@ -927,32 +1300,288 @@ def stats():
     frees = __cl_sync.get_frees()
     display_unit = __config['display_unit']
     for remote in sizes:
-        percent_use = frees[remote] * 100 / sizes[remote]
-        size_d = common.convert_unit(sizes[remote], display_unit)
-        free_d = common.convert_unit(frees[remote], display_unit)
+        percent_use = _format_percent(frees[remote], sizes[remote])
         common.print_line(remote.ljust(15) + " " +
-                          "{:,}".format(size_d).rjust(19) + display_unit + " " +
-                          "{:,}".format(free_d).rjust(19) + display_unit + " " +
-                          "{:,}".format(int(percent_use)).rjust(10)
+                          _format_amount(sizes[remote], display_unit).rjust(20) + " " +
+                          _format_amount(frees[remote], display_unit).rjust(20) + " " +
+                          percent_use.rjust(10)
                           )
 
     size = __cl_sync.get_size()
     free = __cl_sync.get_free()
     logging.debug('size: ' + "{:,}".format(size))
     logging.debug('free: ' + "{:,}".format(free))
-    percent_use = free * 100 / size
+    percent_use = _format_percent(free, size)
     common.print_line(''.join('-' for i in range(15)) + " " +
                       ''.join('-' for i in range(20)) + " " +
                       ''.join('-' for i in range(20)) + " " +
                       ''.join('-' for i in range(10))
                       )
-    size_d = common.convert_unit(size, display_unit)
-    free_d = common.convert_unit(free, display_unit)
     common.print_line("total:".ljust(15) + " " +
-                      "{:,}".format(size_d).rjust(19) + display_unit + " " +
-                      "{:,}".format(free_d).rjust(19) + display_unit + " " +
-                      "{:,}".format(int(percent_use)).rjust(10)
+                      _format_amount(size, display_unit).rjust(20) + " " +
+                      _format_amount(free, display_unit).rjust(20) + " " +
+                      percent_use.rjust(10)
                       )
+
+
+def _service_account_registry():
+    return service_accounts.ServiceAccountRegistry(
+        __config['sa_db'],
+        __config['sa_store'],
+        __config['sa_cache_ttl_hours'],
+    )
+
+
+def _format_amount(amount, display_unit):
+    if amount is None:
+        return 'UNKNOWN'
+    return "{:,}{}".format(common.convert_unit(amount, display_unit), display_unit)
+
+
+def _format_percent(free, total):
+    if free is None or total is None or total == 0:
+        return 'UNKNOWN'
+    return "{:,}".format(int(free * 100 / total))
+
+
+def _sa_import_progress(event):
+    event_type = event.get("event")
+    if event_type == "start":
+        common.print_line("service account import: found " + str(event.get("total", 0)) + " json files")
+        return
+    if event_type != "status":
+        return
+    status = event.get("status")
+    path = event.get("path") or ""
+    basename = os.path.basename(path)
+    prefix = "service account import [{}/{}] ".format(event.get("index"), event.get("total"))
+    message = prefix + status + ": " + basename
+    reason = event.get("reason")
+    if reason:
+        message += " - " + reason
+    common.print_line(message)
+
+
+def _service_account_live_validator(path, payload):
+    fd, tmp_conf = tempfile.mkstemp(prefix="rclone-sa-import-", suffix=".conf")
+    os.close(fd)
+    try:
+        rclone.generate_rclone_config_from_files(
+            [path],
+            tmp_conf,
+            None,
+            prefix="sa_import",
+            start_index=1,
+            shuffle=False,
+        )
+        rclone_exe = __config.get('rclone_exe', 'rclone')
+        rclone_retries = __config.get('rclone_retries', '1')
+        rc = rclone.RClone(tmp_conf, rclone_exe, rclone_retries)
+        quota, error = rc.get_about_json_with_error("sa_import1:")
+        if error is not None:
+            return None, _friendly_rclone_error(error, payload)
+        unknown_reason = _quota_unknown_reason(quota)
+        if unknown_reason is not None:
+            return None, unknown_reason
+        return quota, None
+    finally:
+        try:
+            os.unlink(tmp_conf)
+        except Exception:
+            pass
+
+
+def _quota_unknown_reason(quota):
+    if not isinstance(quota, dict):
+        return "rclone about returned unknown quota"
+    missing = []
+    for field in ("total", "free"):
+        if field not in quota or quota.get(field) is None:
+            missing.append(field)
+    if missing:
+        return "rclone about returned unknown quota: missing " + ",".join(missing)
+    return None
+
+
+def _friendly_rclone_error(error, identity=None):
+    text = " ".join(str(error).split())
+    if len(text) > 320:
+        text = text[:317] + "..."
+    lower = text.lower()
+    account = ""
+    if identity is not None:
+        email = _identity_value(identity, "client_email")
+        project = _identity_value(identity, "project_id")
+        if email or project:
+            account = " for"
+            if email:
+                account += " " + email
+            if project:
+                account += " project " + project
+    if "executable not found" in lower or "no such file" in lower:
+        return "rclone executable not found" + account
+    if "invalid_grant" in lower or "jwt" in lower or "invalid_client" in lower:
+        return "service account credentials rejected" + account + ": " + text
+    if "project" in lower and ("not found" in lower or "deleted" in lower or "disabled" in lower):
+        return "service account project not available" + account + ": " + text
+    if "service_disabled" in lower or "accessnotconfigured" in lower or "api has not been used" in lower:
+        return "Google Drive API is not available for project" + account + ": " + text
+    if "notfound" in lower or "not found" in lower:
+        return "service account user, project, or Drive target was not found" + account + ": " + text
+    if text == "":
+        return "rclone about failed with no error output" + account
+    return "rclone about failed" + account + ": " + text
+
+
+def _identity_value(identity, key):
+    if hasattr(identity, "get"):
+        return identity.get(key)
+    try:
+        return identity[key]
+    except Exception:
+        return None
+
+
+def sa_import():
+    if len(__args) < 2:
+        logging.error('invalid sa-import command')
+        usage_sa_import()
+        sys.exit(-1)
+    registry = _service_account_registry()
+    result = registry.import_paths(
+        __args[1:],
+        __config['sa_clean_invalid'],
+        validator=_service_account_live_validator,
+        progress=_sa_import_progress,
+    )
+    common.print_line('service account import complete')
+    common.print_line('scanned:      ' + str(result.scanned))
+    common.print_line('validated:    ' + str(result.validated))
+    common.print_line('imported:     ' + str(result.imported))
+    common.print_line('duplicates:   ' + str(result.duplicates))
+    common.print_line('invalid:      ' + str(result.invalid))
+    common.print_line('validation errors: ' + str(result.validation_errors))
+    common.print_line('quarantined:  ' + str(result.quarantined))
+    common.print_line('deleted:      ' + str(result.deleted))
+    common.print_line('store:        ' + os.path.abspath(os.path.expanduser(__config['sa_store'])))
+    common.print_line('database:     ' + os.path.abspath(os.path.expanduser(__config['sa_db'])))
+
+
+def sa_stats():
+    registry = _service_account_registry()
+    refresh_mode = __config['sa_refresh']
+    if globals().get('__sa_refresh') is None and refresh_mode == service_accounts.DEFAULT_REFRESH_MODE:
+        refresh_mode = 'stale'
+    refreshed = 0
+    for account in registry.active_accounts():
+        quota_row = registry.quota_by_account_id(account['id'])
+        if registry.should_refresh(quota_row, refresh_mode):
+            quota, error = _refresh_service_account_quota(account)
+            registry.update_quota(account['id'], quota, error)
+            refreshed += 1
+
+    counts = registry.summary_counts()
+    rows = registry.all_account_stats()
+    active_rows = [row for row in rows if row['status'] == 'active']
+    stale_count = 0
+    error_count = 0
+    unknown_count = 0
+    total = 0
+    used = 0
+    free = 0
+    for row in active_rows:
+        if row['last_about_at'] is None:
+            unknown_count += 1
+        elif registry.is_stale(row['last_about_at']):
+            stale_count += 1
+        if row['last_error'] is not None:
+            error_count += 1
+        if row['total'] is not None:
+            total += row['total']
+        if row['used'] is not None:
+            used += row['used']
+        if row['free'] is not None:
+            free += row['free']
+
+    common.print_line('SERVICE ACCOUNT SUMMARY')
+    common.print_line('active:      ' + str(counts.get('active', 0)))
+    common.print_line('duplicates:  ' + str(counts.get('duplicate', 0)))
+    common.print_line('invalid:     ' + str(counts.get('invalid', 0)))
+    common.print_line('refreshed:   ' + str(refreshed))
+    common.print_line('errors:      ' + str(error_count))
+    common.print_line('stale:       ' + str(stale_count))
+    common.print_line('unknown:     ' + str(unknown_count))
+    common.print_line('')
+    common.print_line('ACCOUNT'.ljust(44) + " " +
+                      'SIZE'.rjust(12) + " " +
+                      'USED'.rjust(12) + " " +
+                      'FREE'.rjust(12) + " " +
+                      '%FREE'.rjust(8) + " " +
+                      'UPDATED'.ljust(20) + " " +
+                      'ERROR')
+    common.print_line(''.join('=' for i in range(44)) + " " +
+                      ''.join('=' for i in range(12)) + " " +
+                      ''.join('=' for i in range(12)) + " " +
+                      ''.join('=' for i in range(12)) + " " +
+                      ''.join('=' for i in range(8)) + " " +
+                      ''.join('=' for i in range(20)) + " " +
+                      ''.join('=' for i in range(20)))
+    display_unit = __config['display_unit']
+    for row in active_rows:
+        account = row['client_email'] or row['account_key'] or str(row['id'])
+        if len(account) > 44:
+            account = account[:41] + '...'
+        common.print_line(account.ljust(44) + " " +
+                          _format_amount(row['total'], display_unit).rjust(12) + " " +
+                          _format_amount(row['used'], display_unit).rjust(12) + " " +
+                          _format_amount(row['free'], display_unit).rjust(12) + " " +
+                          _format_percent(row['free'], row['total']).rjust(8) + " " +
+                          str(row['last_about_at'] or 'UNKNOWN').ljust(20) + " " +
+                          str(row['last_error'] or ''))
+    common.print_line(''.join('-' for i in range(44)) + " " +
+                      ''.join('-' for i in range(12)) + " " +
+                      ''.join('-' for i in range(12)) + " " +
+                      ''.join('-' for i in range(12)) + " " +
+                      ''.join('-' for i in range(8)) + " " +
+                      ''.join('-' for i in range(20)) + " " +
+                      ''.join('-' for i in range(20)))
+    common.print_line('total:'.ljust(44) + " " +
+                      _format_amount(total, display_unit).rjust(12) + " " +
+                      _format_amount(used, display_unit).rjust(12) + " " +
+                      _format_amount(free, display_unit).rjust(12) + " " +
+                      _format_percent(free, total).rjust(8))
+
+
+def _refresh_service_account_quota(account):
+    if account['managed_path'] is None:
+        return None, 'missing managed service account file'
+    fd, tmp_conf = tempfile.mkstemp(prefix="rclone-sa-", suffix=".conf")
+    os.close(fd)
+    try:
+        rclone.generate_rclone_config_from_files(
+            [account['managed_path']],
+            tmp_conf,
+            __config.get('drive_id'),
+            prefix="sa",
+            start_index=1,
+        )
+        rclone_exe = __config.get('rclone_exe', 'rclone')
+        rclone_retries = __config.get('rclone_retries', '1')
+        rc = rclone.RClone(tmp_conf, rclone_exe, rclone_retries)
+        quota, error = rc.get_about_json_with_error("sa1:")
+        if error is not None:
+            return None, _friendly_rclone_error(error, account)
+        unknown_reason = _quota_unknown_reason(quota)
+        if unknown_reason is not None:
+            return None, unknown_reason
+        return quota, None
+    except Exception as e:
+        return None, str(e)
+    finally:
+        try:
+            os.unlink(tmp_conf)
+        except Exception:
+            pass
 
 
 def remove_duplicates():
@@ -1035,7 +1664,12 @@ def check_prerequisites():
 
 def main(argv):
     read_args(argv)
+    if len(__args) > 0 and __args[0] == 'config':
+        config_command(output_path=__configfile)
+        sys.exit(0)
     configure(__configfile)
+    if command_needs_rclone_config():
+        prepare_rclone_sa_config()
     verify_configuration()
     if __check_prereq is not None and __check_prereq is True:
         check_prerequisites()
@@ -1084,6 +1718,10 @@ def main(argv):
             restore()
         elif __args[0] == 'stats':
             stats()
+        elif __args[0] == 'sa-import':
+            sa_import()
+        elif __args[0] == 'sa-stats':
+            sa_stats()
         elif __args[0] == 'removedups':
             remove_duplicates()
         elif __args[0] == 'find':
@@ -1102,6 +1740,10 @@ def main(argv):
                     usage_restore()
                 elif __args[1] == 'stats':
                     usage_stats()
+                elif __args[1] == 'sa-import':
+                    usage_sa_import()
+                elif __args[1] == 'sa-stats':
+                    usage_sa_stats()
                 elif __args[1] == 'removedups':
                     usage_removedups()
                 elif __args[1] == 'config':

--- a/tests/test_rclone_sa_dir_option.py
+++ b/tests/test_rclone_sa_dir_option.py
@@ -1,12 +1,25 @@
 from pathlib import Path
+import json
 import sprinkle
+
+
+def service_account(email, key_id):
+    return {
+        "type": "service_account",
+        "project_id": "synthetic-project",
+        "private_key_id": key_id,
+        "private_key": "-----BEGIN PRIVATE KEY-----\nfake-test-key\n-----END PRIVATE KEY-----\n",
+        "client_email": email,
+        "client_id": key_id,
+        "token_uri": "https://oauth2.googleapis.com/token",
+    }
 
 
 def test_rclone_sa_dir_option(tmp_path):
     sa_dir = tmp_path / "accounts"
     sa_dir.mkdir()
     for i in range(2):
-        (sa_dir / f"{i}.json").write_text("{}")
+        (sa_dir / f"{i}.json").write_text(json.dumps(service_account(f"{i}@example.test", str(i))))
     sprinkle.read_args([
         "--rclone-sa-dir",
         str(sa_dir),
@@ -16,6 +29,8 @@ def test_rclone_sa_dir_option(tmp_path):
         "drive-id",
         "ls",
     ])
+    sprinkle.configure(None)
+    sprinkle.prepare_rclone_sa_config()
     conf_path = Path(sprinkle.__rclone_conf)
     assert conf_path.exists()
     content = conf_path.read_text()

--- a/tests/test_service_accounts_unittest.py
+++ b/tests/test_service_accounts_unittest.py
@@ -1,0 +1,443 @@
+import json
+import os
+import stat
+import sys
+import tempfile
+import types
+import unittest
+
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
+
+
+progress_module = types.ModuleType("progress")
+bar_module = types.ModuleType("progress.bar")
+daemons_module = types.ModuleType("daemons")
+prefab_module = types.ModuleType("daemons.prefab")
+run_module = types.ModuleType("daemons.prefab.run")
+filelock_module = types.ModuleType("filelock")
+
+
+class DummyBar(object):
+    def __init__(self, *args, **kwargs):
+        self.message = ""
+
+    def next(self):
+        return None
+
+    def finish(self):
+        return None
+
+
+bar_module.Bar = DummyBar
+run_module.RunDaemon = object
+filelock_module.Timeout = Exception
+filelock_module.FileLock = lambda *args, **kwargs: None
+sys.modules.setdefault("progress", progress_module)
+sys.modules.setdefault("progress.bar", bar_module)
+sys.modules.setdefault("daemons", daemons_module)
+sys.modules.setdefault("daemons.prefab", prefab_module)
+sys.modules.setdefault("daemons.prefab.run", run_module)
+sys.modules.setdefault("filelock", filelock_module)
+
+import sprinkle
+from libsprinkle import common
+from libsprinkle import clsync
+from libsprinkle import rclone
+from libsprinkle import service_accounts
+
+
+def make_service_account(email, key_id="key-id", client_id="client-id"):
+    return {
+        "type": "service_account",
+        "project_id": "synthetic-project",
+        "private_key_id": key_id,
+        "private_key": "-----BEGIN PRIVATE KEY-----\nfake-test-key\n-----END PRIVATE KEY-----\n",
+        "client_email": email,
+        "client_id": client_id,
+        "auth_uri": "https://accounts.google.com/o/oauth2/auth",
+        "token_uri": "https://oauth2.googleapis.com/token",
+        "auth_provider_x509_cert_url": "https://www.googleapis.com/oauth2/v1/certs",
+        "client_x509_cert_url": "https://www.googleapis.com/robot/v1/metadata/x509/test",
+        "universe_domain": "googleapis.com",
+    }
+
+
+def write_json(path, payload):
+    with open(path, "w") as fp:
+        json.dump(payload, fp)
+
+
+class ServiceAccountRegistryTest(unittest.TestCase):
+    def test_import_dedupes_and_quarantines_invalid_accounts(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            source = os.path.join(tmp, "source")
+            store = os.path.join(tmp, "store")
+            db_path = os.path.join(tmp, "sa.sqlite3")
+            os.mkdir(source)
+
+            write_json(os.path.join(source, "one.json"), make_service_account("one@example.test"))
+            write_json(os.path.join(source, "duplicate.json"), make_service_account("one@example.test"))
+            invalid = make_service_account("invalid@example.test")
+            invalid.pop("client_id")
+            write_json(os.path.join(source, "invalid.json"), invalid)
+
+            registry = service_accounts.ServiceAccountRegistry(db_path, store)
+            result = registry.import_paths([source])
+
+            self.assertEqual(result.scanned, 3)
+            self.assertEqual(result.imported, 1)
+            self.assertEqual(result.duplicates, 1)
+            self.assertEqual(result.invalid, 1)
+            self.assertEqual(result.quarantined, 1)
+            self.assertEqual(len(result.selected_files), 1)
+
+            active = registry.active_accounts()
+            self.assertEqual(len(active), 1)
+            self.assertTrue(os.path.basename(active[0]["managed_path"]).startswith("sa-"))
+            self.assertEqual(stat.S_IMODE(os.stat(active[0]["managed_path"]).st_mode), 0o600)
+            self.assertEqual(stat.S_IMODE(os.stat(store).st_mode), 0o700)
+            self.assertEqual(len(os.listdir(os.path.join(store, "quarantine"))), 1)
+
+    def test_quota_error_preserves_cached_values(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            source = os.path.join(tmp, "source")
+            os.mkdir(source)
+            write_json(os.path.join(source, "one.json"), make_service_account("one@example.test"))
+
+            registry = service_accounts.ServiceAccountRegistry(
+                os.path.join(tmp, "sa.sqlite3"),
+                os.path.join(tmp, "store"),
+            )
+            registry.import_paths([source])
+            account = registry.active_accounts()[0]
+
+            registry.update_quota(account["id"], {"total": 100, "used": 60, "free": 40}, None)
+            registry.update_quota(account["id"], None, "rclone about failed")
+            quota = registry.quota_by_account_id(account["id"])
+
+            self.assertEqual(quota["total"], 100)
+            self.assertEqual(quota["used"], 60)
+            self.assertEqual(quota["free"], 40)
+            self.assertEqual(quota["last_error"], "rclone about failed")
+
+    def test_import_validator_stores_quota_and_reports_progress(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            source = os.path.join(tmp, "source")
+            os.mkdir(source)
+            write_json(os.path.join(source, "one.json"), make_service_account("one@example.test"))
+            events = []
+
+            def validator(_path, _payload):
+                return {"total": 100, "used": 25, "free": 75}, None
+
+            registry = service_accounts.ServiceAccountRegistry(
+                os.path.join(tmp, "sa.sqlite3"),
+                os.path.join(tmp, "store"),
+            )
+            result = registry.import_paths([source], validator=validator, progress=events.append)
+            account = registry.active_accounts()[0]
+            quota = registry.quota_by_account_id(account["id"])
+
+            self.assertEqual(result.total, 1)
+            self.assertEqual(result.validated, 1)
+            self.assertEqual(result.imported, 1)
+            self.assertEqual(quota["total"], 100)
+            self.assertEqual(quota["free"], 75)
+            self.assertEqual(events[0]["event"], "start")
+            self.assertEqual(events[-1]["event"], "complete")
+            self.assertTrue(any(event.get("status") == "imported" for event in events))
+
+    def test_import_validator_unknown_quarantines_account(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            source = os.path.join(tmp, "source")
+            os.mkdir(source)
+            write_json(os.path.join(source, "unknown.json"), make_service_account("unknown@example.test"))
+
+            def validator(_path, _payload):
+                return None, "rclone about returned unknown quota: missing free"
+
+            registry = service_accounts.ServiceAccountRegistry(
+                os.path.join(tmp, "sa.sqlite3"),
+                os.path.join(tmp, "store"),
+            )
+            result = registry.import_paths([source], validator=validator)
+            rows = registry.all_account_stats()
+
+            self.assertEqual(result.imported, 0)
+            self.assertEqual(result.invalid, 1)
+            self.assertEqual(result.validation_errors, 1)
+            self.assertEqual(result.quarantined, 1)
+            self.assertEqual(len(registry.active_accounts()), 0)
+            self.assertEqual(rows[0]["status"], "invalid")
+            self.assertIn("unknown quota", rows[0]["invalid_reason"])
+            self.assertEqual(len(os.listdir(os.path.join(tmp, "store", "quarantine"))), 1)
+
+
+class RCloneQuotaTest(unittest.TestCase):
+    def test_about_json_is_reused_for_size_and_free(self):
+        calls = []
+        old_execute = common.execute
+
+        def fake_execute(command, no_error=False):
+            calls.append(command)
+            return {
+                "code": 0,
+                "out": json.dumps({"total": 100, "used": 25, "free": 75}),
+                "error": "",
+            }
+
+        try:
+            common.execute = fake_execute
+            rc = rclone.RClone()
+            self.assertEqual(rc.get_size("dst101:"), 100)
+            self.assertEqual(rc.get_free("dst101:"), 75)
+            self.assertEqual(calls[0][1], "about")
+            self.assertIn("--json", calls[0])
+        finally:
+            common.execute = old_execute
+
+    def test_about_json_with_error_preserves_rclone_stderr(self):
+        old_execute = common.execute
+
+        def fake_execute(_command, no_error=False):
+            return {
+                "code": 1,
+                "out": "",
+                "error": "invalid_grant: Invalid JWT Signature",
+            }
+
+        try:
+            common.execute = fake_execute
+            rc = rclone.RClone()
+            quota, error = rc.get_about_json_with_error("dst101:")
+        finally:
+            common.execute = old_execute
+
+        self.assertIsNone(quota)
+        self.assertIn("invalid_grant", error)
+        friendly = sprinkle._friendly_rclone_error(
+            error,
+            {"client_email": "one@example.test", "project_id": "project-one"},
+        )
+        self.assertIn("credentials rejected", friendly)
+        self.assertIn("one@example.test", friendly)
+
+    def test_unknown_quota_reason_requires_total_and_free(self):
+        self.assertIn("missing total,free", sprinkle._quota_unknown_reason({"used": 1}))
+        self.assertIsNone(sprinkle._quota_unknown_reason({"total": 100, "free": 0}))
+
+    def test_generate_rclone_config_from_explicit_files_returns_remote_mapping(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            sa_file = os.path.join(tmp, "account.json")
+            write_json(sa_file, make_service_account("one@example.test"))
+            out = os.path.join(tmp, "rclone.conf")
+
+            content, entries = rclone.generate_rclone_config_from_files(
+                [sa_file],
+                out,
+                "drive-id",
+                start_index=1,
+                return_entries=True,
+            )
+
+            self.assertEqual(entries, [{"remote": "dst1", "path": sa_file}])
+            self.assertIn("service_account_file = " + sa_file, content)
+            self.assertIn("root_folder_id = drive-id", content)
+
+    def test_generate_rclone_config_can_disable_shuffle_for_stable_selection(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            first = os.path.join(tmp, "b.json")
+            second = os.path.join(tmp, "a.json")
+            write_json(first, make_service_account("b@example.test", "key-b"))
+            write_json(second, make_service_account("a@example.test", "key-a"))
+            out = os.path.join(tmp, "rclone.conf")
+
+            content, entries = rclone.generate_rclone_config_from_files(
+                [first, second],
+                out,
+                "drive-id",
+                max_accounts=1,
+                start_index=1,
+                return_entries=True,
+                shuffle=False,
+            )
+
+            self.assertEqual(entries, [{"remote": "dst1", "path": second}])
+            self.assertIn("service_account_file = " + second, content)
+
+    def test_generate_combine_config_groups_local_upstreams(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            out = os.path.join(tmp, "combine.conf")
+            content = rclone.generate_rclone_combine_config(
+                ["one={}".format(os.path.join(tmp, "one")), "two={}".format(os.path.join(tmp, "two"))],
+                out,
+                group_size=1,
+            )
+
+            self.assertIn("[sa_group1]", content)
+            self.assertIn("[sa_group2]", content)
+            self.assertIn("type = combine", content)
+            self.assertIn("upstreams = one=", content)
+
+
+class ClSyncPlacementTest(unittest.TestCase):
+    def test_large_file_selection_requires_headroom(self):
+        sync = clsync.ClSync.__new__(clsync.ClSync)
+        sync._distribution_type = "mas"
+        sync._cached_free = {}
+        sync._large_file_threshold_bytes = 1024
+        sync._large_file_min_free_bytes = 100
+        sync._large_file_min_free_percent = 10
+        sync.get_remotes = lambda: ["tight:", "roomy:"]
+        quotas = {
+            "tight:": {"free": 1099},
+            "roomy:": {"free": 2000},
+        }
+        sync._get_remote_quota = lambda remote: quotas[remote]
+
+        self.assertEqual(sync.get_best_remote(1000), "roomy:")
+
+    def test_small_file_selection_keeps_existing_most_free_behavior(self):
+        sync = clsync.ClSync.__new__(clsync.ClSync)
+        sync._distribution_type = "mas"
+        sync._cached_free = {}
+        sync._large_file_threshold_bytes = 1024
+        sync._large_file_min_free_bytes = 100
+        sync._large_file_min_free_percent = 10
+        sync.get_remotes = lambda: ["one:", "two:"]
+        quotas = {
+            "one:": {"free": 500},
+            "two:": {"free": 700},
+        }
+        sync._get_remote_quota = lambda remote: quotas[remote]
+
+        self.assertEqual(sync.get_best_remote(100), "two:")
+
+    def test_existing_update_remote_must_have_headroom(self):
+        sync = clsync.ClSync.__new__(clsync.ClSync)
+        sync._distribution_type = "mas"
+        sync._cached_free = {}
+        sync._large_file_threshold_bytes = 1024
+        sync._large_file_min_free_bytes = 100
+        sync._large_file_min_free_percent = 10
+        sync._get_remote_quota = lambda _remote: {"free": 1099}
+
+        with self.assertRaises(Exception):
+            sync.ensure_remote_has_enough_space("tight:", 1024)
+
+
+class ServiceAccountCliTest(unittest.TestCase):
+    def test_rclone_sa_dir_imports_deduped_managed_accounts(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            source = os.path.join(tmp, "source")
+            store = os.path.join(tmp, "store")
+            db_path = os.path.join(tmp, "sa.sqlite3")
+            os.mkdir(source)
+
+            write_json(os.path.join(source, "one.json"), make_service_account("one@example.test"))
+            write_json(os.path.join(source, "dupe.json"), make_service_account("one@example.test"))
+
+            sprinkle.read_args([
+                "--rclone-sa-dir",
+                source,
+                "--rclone-sa-count",
+                "1",
+                "--drive-id",
+                "drive-id",
+                "--sa-db",
+                db_path,
+                "--sa-store",
+                store,
+                "stats",
+            ])
+            sprinkle.configure(None)
+            sprinkle.prepare_rclone_sa_config()
+            conf_path = getattr(sprinkle, "__rclone_conf")
+            self.assertTrue(os.path.exists(conf_path))
+            with open(conf_path) as fp:
+                content = fp.read()
+            self.assertEqual(content.count("[dst"), 1)
+            self.assertIn("root_folder_id = drive-id", content)
+            self.assertIn(os.path.abspath(store), content)
+            os.unlink(conf_path)
+
+    def test_config_command_writes_home_style_defaults(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            output = os.path.join(tmp, "sprinkle.conf")
+            answers = iter(["", "", "", "", "drive-folder", "", "", "", ""])
+
+            def prompt(_message):
+                return next(answers)
+
+            sprinkle.config_command(prompt, output)
+            with open(output) as fp:
+                content = fp.read()
+
+            self.assertIn("rclone_move=true", content)
+            self.assertIn("delete_files=false", content)
+            self.assertIn("debug=true", content)
+            self.assertIn("rclone_sa_count=5", content)
+            self.assertIn("drive_id=drive-folder", content)
+            self.assertIn("rclone_sa_dir=/etc/rclone/sa", content)
+            self.assertIn("sa_cache_ttl_hours=72", content)
+            self.assertIn("sa_refresh=stale", content)
+            self.assertIn("sa_clean_invalid=quarantine", content)
+            self.assertIn("large_file_threshold_bytes=1073741824", content)
+
+    def test_config_command_defaults_to_home_sprinkle_config_path(self):
+        old_home = os.environ.get("HOME")
+        with tempfile.TemporaryDirectory() as tmp:
+            os.environ["HOME"] = tmp
+            answers = iter(["", "", "", "", "", "", "", "", ""])
+
+            def prompt(_message):
+                return next(answers)
+
+            try:
+                target = sprinkle.config_command(prompt)
+                self.assertEqual(target, os.path.join(tmp, ".sprinkle", "sprinkle.conf"))
+                self.assertTrue(os.path.exists(target))
+            finally:
+                if old_home is None:
+                    os.environ.pop("HOME", None)
+                else:
+                    os.environ["HOME"] = old_home
+
+    def test_config_file_service_account_defaults_generate_rclone_config(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            source = os.path.join(tmp, "source")
+            store = os.path.join(tmp, "store")
+            db_path = os.path.join(tmp, "sa.sqlite3")
+            config_path = os.path.join(tmp, "sprinkle.conf")
+            os.mkdir(source)
+
+            write_json(os.path.join(source, "one.json"), make_service_account("one@example.test"))
+            write_json(os.path.join(source, "two.json"), make_service_account("two@example.test", "key-two"))
+            with open(config_path, "w") as fp:
+                fp.write("\n".join([
+                    "debug=true",
+                    "rclone_move=true",
+                    "delete_files=false",
+                    "rclone_sa_count=1",
+                    "drive_id=drive-id",
+                    "rclone_sa_dir=" + source,
+                    "sa_db=" + db_path,
+                    "sa_store=" + store,
+                ]))
+
+            sprinkle.read_args(["-c", config_path, "stats"])
+            sprinkle.configure(config_path)
+            sprinkle.prepare_rclone_sa_config()
+            generated = getattr(sprinkle, "__rclone_conf")
+            with open(generated) as fp:
+                content = fp.read()
+
+            self.assertTrue(getattr(sprinkle, "__config")["debug"])
+            self.assertFalse(getattr(sprinkle, "__config")["delete_files"])
+            self.assertEqual(content.count("[dst"), 1)
+            self.assertIn("root_folder_id = drive-id", content)
+            os.unlink(generated)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## New Featues

* `sa-import` - import & dedup sa json files 
* `sa-stats` - caches space & keep them organized
*  select best service account based on space 



##### import service accounts:
```
$ python3 sprinkle.py sa-import /path/to/service-accounts
service account import: found 46 json files
service account import [1/46] imported: sa-77757096d8ee3b33cf290d6a.json
service account import [2/46] imported: sa-774a8b4465f01f42f1e45016.json
...
service account import complete
scanned:      46
validated:    46
imported:     46
duplicates:   0
invalid:      0
validation errors: 0
quarantined:  0
deleted:      0
store:        /home/user/.sprinkle/service-accounts
database:     /home/user/.sprinkle/sa-cache.sqlite3
```


##### inspect imported accounts and cached quota:
```
$ python3 sprinkle.py --drive-id GDRIVE_FOLDER_ID sa-stats
SERVICE ACCOUNT SUMMARY
active:      46
duplicates:  0
invalid:     0
refreshed:   0
errors:      0
stale:       0
unknown:     0

ACCOUNT                                              SIZE         USED         FREE    %FREE UPDATED              ERROR
============================================ ============ ============ ============ ======== ==================== ====================
.....
sa5s.......           11.iam.gser...          15G           2G          12G       80 2026-05-25T16:35:04Z 
-------------------------------------------- ------------ ------------ ------------ -------- -------------------- --------------------
total:                                               525G         371G         153G       29

```