### PR TITLE
Release/1.1.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,15 @@
+# Changelog
+
+## 1.1.0
+
+- Added rclone environment file support via `rclone_env_file` and `--rclone-env-file`.
+- Added first-use rollout of `~/.sprinkle/rclone.env` with defaults for Google Drive chunk size, size-only comparison, and modtime handling.
+- Added `--progress` as the preferred progress option and `-v`/`--verbose` to set `RCLONE_VERBOSE=1`; version output remains available through `--version`.
+- Fixed rclone JSON parsing when `RCLONE_PROGRESS=1` appends transfer progress to `lsjson` or `about --json` output.
+- Improved service-account file listing behavior so missing Drive folders with `--ls-stop-first` do not scan every service-account remote.
+- Reduced backup listing work for `delete_files=false` by checking only relevant remote parent directories.
+- Added service-account listing cache support and related regression coverage.
+
+## 1.0.0
+
+- Initial packaged Sprinkle release.

--- a/README.md
+++ b/README.md
@@ -33,10 +33,15 @@ Sprinkle keeps upload placement capacity-aware for large files: service accounts
 $ ./sprinkle.py config
 # writes ~/.sprinkle/sprinkle.conf, including:
 # --rclone-sa-count 5 --drive-id XXXXX -d --rclone-sa-dir /etc/rclone/sa
+# rclone_env_file=~/.sprinkle/rclone.env
 # sa_cache_ttl_hours=72
 # sa_refresh=stale
 # sa_clean_invalid=quarantine
 ```
+
+`~/.sprinkle/rclone.env` is created on first use and exports rclone tuning defaults
+such as `RCLONE_DRIVE_CHUNK_SIZE=256M`, `RCLONE_SIZE_ONLY=1`, and
+`RCLONE_NO_UPDATE_MODTIME=1`. Lines beginning with `#` are ignored.
 
 
 
@@ -106,7 +111,8 @@ and the command specific help.
     -c, --conf {config file}     configuration file
     -d, --debug                  debug output
     -h, --help                   help
-    -v, --version                print version
+    -v, --verbose                set RCLONE_VERBOSE=1 for rclone
+    --version                    print version
     --check-prereq               chech prerequisites
     --comp-method {size|md5}     compare method [size|md5] (default:size)
     --daemon-interval            interval for the daemon to execute in minutes (default:60)
@@ -122,6 +128,7 @@ and the command specific help.
     --log-file {file}            logs output to the specified file
     --no-cache                   turn off caching
     --rclone-conf {config file}  rclone configuration (default:None)
+    --rclone-env-file {file}     file with environment variables for rclone
     --rclone-sa-dir {dir}        build rclone config from service accounts
     --rclone-sa-count {num}      limit number of service accounts used
     --drive-id {id}              Google Drive folder ID for rclone config
@@ -135,7 +142,7 @@ and the command specific help.
     --rclone-move                use 'rclone move' instead of 'rclone copy' (default:false)
     --restore-duplicates         restore files if duplicates are found (default:false)
     --retries {num_retries}      number of retries (default:1)
-    --show-progress              show progress
+    --progress                   show progress
     --single-instance            make sure only 1 concurrent instance of sprinkle is running (default:False)
     --ls-stop-first             stop listing after first remote with files
     

--- a/docs/guide.md
+++ b/docs/guide.md
@@ -59,13 +59,13 @@ for the respective operating system:
 ```
 C:\>python sprinkle.py --version
 VERSION:
-    1.0.0, module version: 1.0.0, rclone module version: 1.0.2
+    1.1.0, module version: 1.1.0, rclone module version: 1.1.0
 ```
 ##### for Linux:
 ```
 $  sprinkle.py --version
 VERSION:
-    1.0.0, module version: 1.0.0, rclone module version: 1.0.2
+    1.1.0, module version: 1.1.0, rclone module version: 1.1.0
 ```
 At this point, you can check prerequisites with the following command:
 ```

--- a/libsprinkle/clfile.py
+++ b/libsprinkle/clfile.py
@@ -6,7 +6,7 @@ __author__ = "Michael Montuori [michael.montuori@gmail.com]"
 __copyright__ = "Copyright 2017 Michael Montuori. All rights reserved."
 __credits__ = ["Warren Crigger"]
 __license__ = "GPLv3"
-__version__ = "1.0"
+__version__ = "1.1"
 __revision__ = "0"
 
 class ClFile(object):

--- a/libsprinkle/clsync.py
+++ b/libsprinkle/clsync.py
@@ -96,8 +96,8 @@ class ClSync:
         else:
             self.__exclude_regex = None
 
-        self._cache = None
-        self._cache_counter = 0
+        self._cache = {}
+        self._cache_counter = {}
         self._cache_invalidation_max = 1440 / (config['daemon_interval'] * 2)
         if self._cache_invalidation_max < 1:
             self._cache_invalidation_max = 1
@@ -129,19 +129,26 @@ class ClSync:
             self._rclone.mkdir(remote, directory)
 
     def ls(self, file, with_dups=False, regex=None, stop_after_first=None):
+        return self._ls(file, with_dups, regex, stop_after_first, recursive=True)
+
+    def ls_shallow(self, file, with_dups=False, regex=None, stop_after_first=None):
+        return self._ls(file, with_dups, regex, stop_after_first, recursive=False)
+
+    def _ls(self, file, with_dups=False, regex=None, stop_after_first=None, recursive=True):
         logging.debug('lsjson of file: ' + file)
         if stop_after_first is None:
             stop_after_first=self._config['ls_stop_first']
-        if self._config['no_cache'] is False and self._cache is not None:
-            logging.debug('serving cached version of file list...')
-            self._cache_counter += 1
-            if self._cache_counter <= self._cache_invalidation_max:
-                return self._cache
-            else:
-                self._cache_counter = 0
         if not file.startswith('/'):
             logging.debug('adding / ' + file)
             file = '/' + file
+        memory_cache_key = (file, with_dups, regex, stop_after_first, recursive)
+        if self._config['no_cache'] is False and memory_cache_key in self._cache:
+            logging.debug('serving cached version of file list...')
+            self._cache_counter[memory_cache_key] += 1
+            if self._cache_counter[memory_cache_key] <= self._cache_invalidation_max:
+                return self._cache[memory_cache_key]
+            else:
+                self._cache_counter[memory_cache_key] = 0
         if regex is not None:
             regexp = re.compile(regex)
         else:
@@ -153,10 +160,7 @@ class ClSync:
         for remote in self.get_remotes():
             common.print_line('retrieving file list from: ' + remote + file + '...')
             logging.debug('getting lsjson from ' + remote + file)
-            try:
-                json_out = self._rclone.lsjson(remote, file, ['--recursive', '--fast-list'], True)
-            except exceptions.FileNotFoundException as e:
-                json_out = '[]'
+            json_out = self._cached_lsjson(remote, file, recursive)
             logging.debug('loading json')
             tmp_json = json.loads(json_out)
             logging.debug('json size: ' + str(len(tmp_json)))
@@ -181,11 +185,97 @@ class ClSync:
                     key = key + ClSync.duplicate_suffix
                 files[key] = tmp_file
                 if stop_after_first and len(files) > 0:
+                    self._store_memory_ls_cache(memory_cache_key, files)
                     return files
+            if stop_after_first and self._stop_after_first_success():
+                self._store_memory_ls_cache(memory_cache_key, files)
+                return files
             logging.debug('end of clsync.ls()')
-        if self._config['no_cache'] is False and self._cache is None:
-            self._cache = files
+        self._store_memory_ls_cache(memory_cache_key, files)
         return files
+
+    def _cached_lsjson(self, remote, path, recursive=True):
+        if self._config['no_cache'] is False and self._sa_registry is not None:
+            cached = self._sa_registry.ls_cache_by_remote(remote, path)
+            if cached is not None and not self._sa_registry.should_refresh_ls_cache(cached, self._sa_refresh):
+                logging.debug('serving cached lsjson for ' + remote + path)
+                return self._json_for_listing_depth(cached["json_text"], recursive)
+            if cached is not None and self._sa_refresh == 'none':
+                logging.debug('serving cached lsjson for ' + remote + path)
+                return self._json_for_listing_depth(cached["json_text"], recursive)
+            parent_json = self._json_from_cached_parent(remote, path, recursive)
+            if parent_json is not None:
+                logging.debug('serving parent cached lsjson for ' + remote + path)
+                return parent_json
+        extra_args = ['--fast-list']
+        if recursive:
+            extra_args.insert(0, '--recursive')
+        try:
+            json_out = self._rclone.lsjson(remote, path, extra_args, True)
+        except exceptions.FileNotFoundException as e:
+            json_out = '[]'
+        except Exception as e:
+            if self._config['no_cache'] is False and self._sa_registry is not None:
+                self._sa_registry.update_ls_cache_for_remote(remote, path, None, str(e))
+            raise
+        if recursive and self._config['no_cache'] is False and self._sa_registry is not None:
+            self._sa_registry.update_ls_cache_for_remote(remote, path, json_out, None)
+        return json_out
+
+    def _json_from_cached_parent(self, remote, path, recursive=True):
+        if path == '/':
+            return None
+        root_cache = self._sa_registry.ls_cache_by_remote(remote, '/')
+        if root_cache is None:
+            return None
+        if self._sa_registry.should_refresh_ls_cache(root_cache, self._sa_refresh):
+            return None
+        prefix = path.strip('/')
+        try:
+            rows = json.loads(root_cache["json_text"])
+        except Exception:
+            return None
+        filtered = []
+        for row in rows:
+            if not isinstance(row, dict):
+                continue
+            row_path = row.get("Path", "")
+            if row_path == prefix:
+                continue
+            if not row_path.startswith(prefix + '/'):
+                continue
+            copied = dict(row)
+            copied["Path"] = row_path[len(prefix) + 1:]
+            if not recursive and '/' in copied["Path"]:
+                continue
+            filtered.append(copied)
+        return json.dumps(filtered)
+
+    def _json_for_listing_depth(self, json_text, recursive=True):
+        if recursive:
+            return json_text
+        try:
+            rows = json.loads(json_text)
+        except Exception:
+            return json_text
+        if not isinstance(rows, list):
+            return json_text
+        filtered = []
+        for row in rows:
+            if not isinstance(row, dict):
+                continue
+            if '/' in row.get("Path", ""):
+                continue
+            filtered.append(row)
+        return json.dumps(filtered)
+
+    def _stop_after_first_success(self):
+        return self._config.get('drive_id') not in (None, '')
+
+    def _store_memory_ls_cache(self, cache_key, files):
+        if self._config['no_cache'] is False:
+            self._cache[cache_key] = files
+            self._cache_counter[cache_key] = 0
 
     def lsmd5(self, file, stop_after_first=False):
         logging.debug('lsjson of file: ' + file)
@@ -331,6 +421,8 @@ class ClSync:
                 self._frees[remote] = max(0, self._frees[remote] - int(size))
         if self._sa_registry is not None:
             self._sa_registry.adjust_quota_for_remote(remote, int(size))
+            self._sa_registry.invalidate_ls_cache_for_remote(remote)
+        self._clear_memory_ls_cache()
 
     def _get_remote_quota(self, remote):
         cached = None
@@ -516,6 +608,30 @@ class ClSync:
         common.print_line('found ' + str(len(operations)) + ' differences')
         return operations
 
+    def ls_matching_local_files(self, local_dir, local_clfiles, remote_root=None):
+        if remote_root is None:
+            remote_root = self.get_backup_remote_root(local_dir)
+        wanted_by_parent = {}
+        for local_path in local_clfiles:
+            local_clfile = local_clfiles[local_path]
+            if local_clfile.is_dir:
+                continue
+            remote_key = self.remote_key_for_local_path(
+                local_dir,
+                local_clfile.path + '/' + local_clfile.name,
+                remote_root,
+            )
+            remote_parent = os.path.dirname(remote_key).replace('\\', '/')
+            wanted_by_parent.setdefault(remote_parent, set()).add(remote_key)
+
+        remote_clfiles = {}
+        for remote_parent in sorted(wanted_by_parent):
+            parent_files = self.ls_shallow(remote_parent)
+            for remote_key in wanted_by_parent[remote_parent]:
+                if remote_key in parent_files:
+                    remote_clfiles[remote_key] = parent_files[remote_key]
+        return remote_clfiles
+
     def backup(self, local_dir, delete_files=True, dry_run=False):
         logging.debug('backing up directory ' + local_dir)
         if not common.is_dir(local_dir):
@@ -524,7 +640,10 @@ class ClSync:
         remote_root = self.get_backup_remote_root(local_dir)
         logging.debug('backup remote root: ' + remote_root)
         local_clfiles = self.index_local_dir(local_dir, self.__exclusion_list)
-        remote_clfiles = self.ls(remote_root)
+        if delete_files is True or self._compare_method == 'md5':
+            remote_clfiles = self.ls(remote_root)
+        else:
+            remote_clfiles = self.ls_matching_local_files(local_dir, local_clfiles, remote_root)
         ops = self.compare_clfiles_for_remote_root(
             local_dir,
             local_clfiles,
@@ -631,6 +750,9 @@ class ClSync:
     def rmdir(self, directory, remote):
         logging.debug('removing directory ' + remote+directory)
         self._rclone.rmdir(remote, directory)
+        if self._sa_registry is not None:
+            self._sa_registry.invalidate_ls_cache_for_remote(remote)
+        self._clear_memory_ls_cache()
 
     def get_version(self):
         logging.debug('getting version')
@@ -641,10 +763,16 @@ class ClSync:
     def delete_file(self, file, remote):
         logging.debug('deleting file ' + remote+file)
         self._rclone.delete_file(remote, file)
+        if self._sa_registry is not None:
+            self._sa_registry.invalidate_ls_cache_for_remote(remote)
+        self._clear_memory_ls_cache()
 
     def delete(self, path, remote):
         logging.debug('deleting path ' + remote+path)
         self._rclone.delete(remote, path)
+        if self._sa_registry is not None:
+            self._sa_registry.invalidate_ls_cache_for_remote(remote)
+        self._clear_memory_ls_cache()
 
     def copy(self, src, dst, remote):
         logging.debug('copy ' + src + ' to ' + remote + dst)
@@ -662,6 +790,10 @@ class ClSync:
 
     def move(self, src, dst):
         logging.debug('move ' + src + ' to ' + dst)
+
+    def _clear_memory_ls_cache(self):
+        self._cache = {}
+        self._cache_counter = {}
 
     def sync(self, path):
         logging.debug('synchronize path ' + path)

--- a/libsprinkle/clsync.py
+++ b/libsprinkle/clsync.py
@@ -6,7 +6,7 @@ __author__ = "Michael Montuori [michael.montuori@gmail.com]"
 __copyright__ = "Copyright 2017 Michael Montuori. All rights reserved."
 __credits__ = ["Warren Crigger"]
 __license__ = "GPLv3"
-__version__ = "1.0"
+__version__ = "1.1"
 __revision__ = "0"
 
 import logging

--- a/libsprinkle/common.py
+++ b/libsprinkle/common.py
@@ -6,7 +6,7 @@ __author__ = "Michael Montuori [michael.montuori@gmail.com]"
 __copyright__ = "Copyright 2017 Michael Montuori. All rights reserved."
 __credits__ = ["Warren Crigger"]
 __license__ = "GPLv3"
-__version__ = "1.0"
+__version__ = "1.1"
 __revision__ = "0"
 
 import subprocess

--- a/libsprinkle/config.py
+++ b/libsprinkle/config.py
@@ -6,8 +6,8 @@ __author__ = "Michael Montuori [michael.montuori@gmail.com]"
 __copyright__ = "Copyright 2018, Michael Montuori. All rights reserved."
 __credits__ = ["Warren Crigger"]
 __licemse__ = "GPLv3"
-__version__ = "1.0"
-__revision__ = "1"
+__version__ = "1.1"
+__revision__ = "0"
 __maintainer__ = "Michael Montuori [michael.montuori@gmail.com]"
 
 try:

--- a/libsprinkle/exceptions.py
+++ b/libsprinkle/exceptions.py
@@ -6,8 +6,8 @@ __author__ = "Michael Montuori [michael.montuori@gmail.com]"
 __copyright__ = "Copyright 2017 Michael Montuori. All rights reserved."
 __credits__ = ["Warren Crigger"]
 __license__ = "GPLv3"
-__version__ = "1.0"
-__revision__ = "2"
+__version__ = "1.1"
+__revision__ = "0"
 
 class FileNotFoundException(Exception):
 

--- a/libsprinkle/operation.py
+++ b/libsprinkle/operation.py
@@ -6,8 +6,8 @@ __author__ = "Michael Montuori [michael.montuori@gmail.com]"
 __copyright__ = "Copyright 2017 Michael Montuori. All rights reserved."
 __credits__ = ["Warren Crigger"]
 __license__ = "GPLv3"
-__version__ = "0.1"
-__revision__ = "2"
+__version__ = "1.1"
+__revision__ = "0"
 
 from libsprinkle import clfile
 
@@ -23,4 +23,3 @@ class Operation(object):
         self.operation = operation
         self.src = src
         self.dst = dst
-

--- a/libsprinkle/rclone.py
+++ b/libsprinkle/rclone.py
@@ -6,8 +6,8 @@ __author__ = "Michael Montuori [michael.montuori@gmail.com]"
 __copyright__ = "Copyright 2017 Michael Montuori. All rights reserved."
 __credits__ = ["Warren Crigger"]
 __license__ = "GPLv3"
-__version__ = "1.0"
-__revision__ = "2"
+__version__ = "1.1"
+__revision__ = "0"
 
 import logging
 import json
@@ -15,6 +15,23 @@ import os
 import random
 from libsprinkle import common
 from libsprinkle import exceptions
+
+
+def extract_json_output(text):
+    if text is None:
+        return text
+    if text.strip() == '[':
+        return '[]'
+    decoder = json.JSONDecoder()
+    for index, char in enumerate(text):
+        if char not in ('[', '{'):
+            continue
+        try:
+            value, _end = decoder.raw_decode(text[index:])
+            return json.dumps(value)
+        except ValueError:
+            continue
+    return text
 
 
 def generate_rclone_config(
@@ -203,10 +220,7 @@ class RClone:
                     raise exceptions.FileNotFoundException(result['error'])
                 else:
                     raise Exception('error getting remote object. ' + result['error'])
-        if 'out' in result and result['out'] == '[\n':
-            lsjson = '[]'
-        else:
-            lsjson = result['out']
+        lsjson = extract_json_output(result.get('out'))
         logging.debug('returning ' + str(lsjson)[0:128])
         return lsjson
 
@@ -233,12 +247,9 @@ class RClone:
                     raise exceptions.FileNotFoundException(result['error'])
                 else:
                     raise Exception('error getting remote object. ' + result['error'])
-        if 'out' in result and result['out'] == '[\n':
-            lsjson = '[]'
-        else:
-            lsjson = result['out']
-        logging.debug('returning ' + str(lsjson)[0:128])
-        return lsjson
+        out = result.get('out', '')
+        logging.debug('returning ' + str(out)[0:128])
+        return out
 
     def get_about_json_with_error(self, remote):
         logging.debug('running about for ' + remote)
@@ -261,7 +272,7 @@ class RClone:
         if result.get('out') in (None, ''):
             return None, 'rclone about returned empty output'
         try:
-            return json.loads(result['out']), None
+            return json.loads(extract_json_output(result['out'])), None
         except Exception as exc:
             return None, 'rclone about returned invalid json: {}'.format(exc.__class__.__name__)
 

--- a/libsprinkle/service_accounts.py
+++ b/libsprinkle/service_accounts.py
@@ -104,12 +104,28 @@ class ServiceAccountRegistry(object):
                     FOREIGN KEY(account_id) REFERENCES accounts(id)
                 )
             """)
+            conn.execute("""
+                CREATE TABLE IF NOT EXISTS ls_cache (
+                    account_id INTEGER NOT NULL,
+                    path TEXT NOT NULL,
+                    json_text TEXT NOT NULL,
+                    object_count INTEGER,
+                    dir_count INTEGER,
+                    file_count INTEGER,
+                    last_lsjson_at TEXT,
+                    last_error TEXT,
+                    updated_at TEXT NOT NULL,
+                    PRIMARY KEY(account_id, path),
+                    FOREIGN KEY(account_id) REFERENCES accounts(id)
+                )
+            """)
             conn.execute("CREATE INDEX IF NOT EXISTS idx_accounts_status ON accounts(status)")
             conn.execute("CREATE INDEX IF NOT EXISTS idx_accounts_email ON accounts(client_email)")
             conn.execute("CREATE INDEX IF NOT EXISTS idx_accounts_key_id ON accounts(private_key_id)")
             conn.execute("CREATE INDEX IF NOT EXISTS idx_accounts_hash ON accounts(content_hash)")
             conn.execute("CREATE INDEX IF NOT EXISTS idx_accounts_source ON accounts(source_path)")
             conn.execute("CREATE INDEX IF NOT EXISTS idx_accounts_remote ON accounts(remote_name)")
+            conn.execute("CREATE INDEX IF NOT EXISTS idx_ls_cache_path ON ls_cache(path)")
 
     def import_paths(self, paths, clean_invalid=DEFAULT_CLEAN_INVALID, validator=None, progress=None):
         if clean_invalid not in ("none", "quarantine", "delete"):
@@ -473,6 +489,109 @@ class ServiceAccountRegistry(object):
         age = datetime.datetime.utcnow() - last
         return age.total_seconds() > self.cache_ttl_hours * 3600
 
+    def ls_cache_by_remote(self, remote, path):
+        account = self.quota_by_remote(remote)
+        if account is None:
+            return None
+        return self.ls_cache_by_account_id(account["account_id"], path)
+
+    def ls_cache_by_account_id(self, account_id, path):
+        with self._connect() as conn:
+            return conn.execute(
+                "SELECT * FROM ls_cache WHERE account_id=? AND path=?",
+                (account_id, self._normalize_cache_path(path)),
+            ).fetchone()
+
+    def should_refresh_ls_cache(self, cache_row, mode):
+        if mode == "none":
+            return False
+        if mode == "all":
+            return True
+        if cache_row is None or cache_row["last_lsjson_at"] is None:
+            return mode in ("missing", "stale")
+        if mode == "missing":
+            return False
+        if mode == "stale":
+            return self.is_stale(cache_row["last_lsjson_at"])
+        return False
+
+    def update_ls_cache_for_remote(self, remote, path, json_text, error=None):
+        account = self.quota_by_remote(remote)
+        if account is None:
+            return
+        self.update_ls_cache(account["account_id"], path, json_text, error)
+
+    def update_ls_cache(self, account_id, path, json_text=None, error=None):
+        now = self._utcnow()
+        path = self._normalize_cache_path(path)
+        if error is not None:
+            with self._connect() as conn:
+                existing = conn.execute(
+                    "SELECT account_id FROM ls_cache WHERE account_id=? AND path=?",
+                    (account_id, path),
+                ).fetchone()
+                if existing is None:
+                    conn.execute("""
+                        INSERT INTO ls_cache (
+                            account_id, path, json_text, last_lsjson_at, last_error, updated_at
+                        ) VALUES (?, ?, ?, ?, ?, ?)
+                    """, (account_id, path, "[]", None, error, now))
+                else:
+                    conn.execute("""
+                        UPDATE ls_cache
+                        SET last_error=?, updated_at=?
+                        WHERE account_id=? AND path=?
+                    """, (error, now, account_id, path))
+            return
+
+        json_text = json_text or "[]"
+        object_count, dir_count, file_count = self._lsjson_counts(json_text)
+        with self._connect() as conn:
+            conn.execute("""
+                INSERT INTO ls_cache (
+                    account_id, path, json_text, object_count, dir_count, file_count,
+                    last_lsjson_at, last_error, updated_at
+                ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)
+                ON CONFLICT(account_id, path) DO UPDATE SET
+                    json_text=excluded.json_text,
+                    object_count=excluded.object_count,
+                    dir_count=excluded.dir_count,
+                    file_count=excluded.file_count,
+                    last_lsjson_at=excluded.last_lsjson_at,
+                    last_error=excluded.last_error,
+                    updated_at=excluded.updated_at
+            """, (
+                account_id,
+                path,
+                json_text,
+                object_count,
+                dir_count,
+                file_count,
+                now,
+                None,
+                now,
+            ))
+
+    def ls_cache_summary(self):
+        with self._connect() as conn:
+            row = conn.execute("""
+                SELECT
+                    COUNT(*) AS cached_paths,
+                    COALESCE(SUM(object_count), 0) AS objects,
+                    COALESCE(SUM(file_count), 0) AS files,
+                    COALESCE(SUM(dir_count), 0) AS dirs,
+                    SUM(CASE WHEN last_error IS NOT NULL THEN 1 ELSE 0 END) AS errors
+                FROM ls_cache
+            """).fetchone()
+        return row
+
+    def invalidate_ls_cache_for_remote(self, remote):
+        account = self.quota_by_remote(remote)
+        if account is None:
+            return
+        with self._connect() as conn:
+            conn.execute("DELETE FROM ls_cache WHERE account_id=?", (account["account_id"],))
+
     def update_quota_for_remote(self, remote, quota, error=None):
         row = self.quota_by_remote(remote)
         if row is None:
@@ -548,6 +667,33 @@ class ServiceAccountRegistry(object):
                 SET free=?, used=?, updated_at=?
                 WHERE account_id=?
             """, (free, used, now, row["account_id"]))
+
+    def _normalize_cache_path(self, path):
+        path = path or "/"
+        path = path.replace('\\', '/')
+        if not path.startswith('/'):
+            path = '/' + path
+        while '//' in path:
+            path = path.replace('//', '/')
+        if len(path) > 1 and path.endswith('/'):
+            path = path[:-1]
+        return path
+
+    def _lsjson_counts(self, json_text):
+        try:
+            rows = json.loads(json_text)
+        except Exception:
+            rows = []
+        object_count = len(rows) if isinstance(rows, list) else 0
+        dir_count = 0
+        file_count = 0
+        if isinstance(rows, list):
+            for row in rows:
+                if isinstance(row, dict) and row.get("IsDir"):
+                    dir_count += 1
+                else:
+                    file_count += 1
+        return object_count, dir_count, file_count
 
     @staticmethod
     def _utcnow():

--- a/libsprinkle/smtp_email.py
+++ b/libsprinkle/smtp_email.py
@@ -6,7 +6,7 @@ __author__ = "Michael Montuori [michael.montuori@gmail.com]"
 __copyright__ = "Copyright 2017 Michael Montuori. All rights reserved."
 __credits__ = ["Warren Crigger"]
 __license__ = "GPLv3"
-__version__ = "1.0"
+__version__ = "1.1"
 __revision__ = "0"
 
 import logging

--- a/libsprinkle/sprinkle_daemon.py
+++ b/libsprinkle/sprinkle_daemon.py
@@ -6,7 +6,7 @@ __author__ = "Michael Montuori [michael.montuori@gmail.com]"
 __copyright__ = "Copyright 2018 Michael Montuori. All rights reserved."
 __credits__ = ["Warren Crigger"]
 __license__ = "GPLv3"
-__version__ = "1.0"
+__version__ = "1.1"
 __revision__ = "0"
 __docformat__ = "reStructuredText"
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "sprinkle-py"
-version = "1.0.0"
+version = "1.1.0"
 description = "Sprinkle is a volume clustering utility based on RClone."
 readme = "README.md"
 requires-python = ">=3.6"

--- a/setup.py
+++ b/setup.py
@@ -21,7 +21,7 @@ RUNTIME_REQUIREMENTS = [
 
 setup(
     name="sprinkle-py",
-    version="1.0.0",
+    version="1.1.0",
     packages=["libsprinkle"],
     py_modules=["sprinkle"],
     scripts=["sprinkle.py"],

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -1,5 +1,5 @@
 name: sprinkle
-version: 1.0
+version: 1.1.0
 summary: Sprinkle
 grade: stable
 description: >

--- a/sprinkle.conf
+++ b/sprinkle.conf
@@ -22,6 +22,13 @@
 # rclone configuration file location (use this to override the default config file)
 # rclone_config=
 
+# rclone environment file. Lines starting with # are ignored.
+# Created on first use with defaults:
+# RCLONE_DRIVE_CHUNK_SIZE=256M
+# RCLONE_SIZE_ONLY=1
+# RCLONE_NO_UPDATE_MODTIME=1
+# rclone_env_file=~/.sprinkle/rclone.env
+
 # service account registry database and managed JSON store
 # service account JSON files contain secrets; do not commit the managed store
 # Equivalent CLI defaults can be stored here:

--- a/sprinkle.py
+++ b/sprinkle.py
@@ -1501,14 +1501,25 @@ def sa_stats():
     if globals().get('__sa_refresh') is None and refresh_mode == service_accounts.DEFAULT_REFRESH_MODE:
         refresh_mode = 'stale'
     refreshed = 0
+    files_cached = 0
+    file_cache_errors = 0
     for account in registry.active_accounts():
         quota_row = registry.quota_by_account_id(account['id'])
         if registry.should_refresh(quota_row, refresh_mode):
             quota, error = _refresh_service_account_quota(account)
             registry.update_quota(account['id'], quota, error)
             refreshed += 1
+        ls_cache_row = registry.ls_cache_by_account_id(account['id'], '/')
+        if registry.should_refresh_ls_cache(ls_cache_row, refresh_mode):
+            json_text, error = _refresh_service_account_file_cache(account)
+            registry.update_ls_cache(account['id'], '/', json_text, error)
+            if error is None:
+                files_cached += 1
+            else:
+                file_cache_errors += 1
 
     counts = registry.summary_counts()
+    ls_summary = registry.ls_cache_summary()
     rows = registry.all_account_stats()
     active_rows = [row for row in rows if row['status'] == 'active']
     stale_count = 0
@@ -1536,6 +1547,10 @@ def sa_stats():
     common.print_line('duplicates:  ' + str(counts.get('duplicate', 0)))
     common.print_line('invalid:     ' + str(counts.get('invalid', 0)))
     common.print_line('refreshed:   ' + str(refreshed))
+    common.print_line('file caches: ' + str(files_cached))
+    common.print_line('file cache errors: ' + str(file_cache_errors))
+    common.print_line('cached paths:' + str(ls_summary['cached_paths']))
+    common.print_line('cached files:' + str(ls_summary['files']))
     common.print_line('errors:      ' + str(error_count))
     common.print_line('stale:       ' + str(stale_count))
     common.print_line('unknown:     ' + str(unknown_count))
@@ -1605,6 +1620,32 @@ def _refresh_service_account_quota(account):
         return quota, None
     except Exception as e:
         return None, str(e)
+    finally:
+        try:
+            os.unlink(tmp_conf)
+        except Exception:
+            pass
+
+
+def _refresh_service_account_file_cache(account):
+    if account['managed_path'] is None:
+        return None, 'missing managed service account file'
+    fd, tmp_conf = tempfile.mkstemp(prefix="rclone-sa-files-", suffix=".conf")
+    os.close(fd)
+    try:
+        rclone.generate_rclone_config_from_files(
+            [account['managed_path']],
+            tmp_conf,
+            __config.get('drive_id'),
+            prefix="sa_files",
+            start_index=1,
+        )
+        rclone_exe = __config.get('rclone_exe', 'rclone')
+        rclone_retries = __config.get('rclone_retries', '1')
+        rc = rclone.RClone(tmp_conf, rclone_exe, rclone_retries)
+        return rc.lsjson("sa_files1:", "/", ['--recursive', '--fast-list'], True), None
+    except Exception as e:
+        return None, _friendly_rclone_error(e, account)
     finally:
         try:
             os.unlink(tmp_conf)

--- a/sprinkle.py
+++ b/sprinkle.py
@@ -6,7 +6,7 @@ __author__ = "Michael Montuori [michael.montuori@gmail.com]"
 __copyright__ = "Copyright 2017 Michael Montuori. All rights reserved."
 __credits__ = ["Warren Crigger"]
 __license__ = "GPLv3"
-__version__ = "1.0"
+__version__ = "1.1"
 __revision__ = "0"
 __docformat__ = "reStructuredText"
 
@@ -33,9 +33,77 @@ except:
 lock = FileLock("sprinkle.lock", timeout=1)
 
 __drive_id = None
+__rclone_env_file = None
+__rclone_verbose = None
+
+DEFAULT_RCLONE_ENV_VALUES = (
+    ("RCLONE_DRIVE_CHUNK_SIZE", "256M"),
+    ("RCLONE_SIZE_ONLY", "1"),
+    ("RCLONE_NO_UPDATE_MODTIME", "1"),
+)
 
 def default_config_path():
     return os.path.join(os.path.expanduser("~"), ".sprinkle", "sprinkle.conf")
+
+
+def default_rclone_env_path():
+    return os.path.join(os.path.expanduser("~"), ".sprinkle", "rclone.env")
+
+
+def default_rclone_env_text():
+    comments = {
+        "RCLONE_DRIVE_CHUNK_SIZE": "Google Drive upload chunk size.",
+        "RCLONE_SIZE_ONLY": "Compare by size only.",
+        "RCLONE_NO_UPDATE_MODTIME": "Do not update remote modtime metadata after upload.",
+    }
+    lines = [
+        "# Sprinkle rclone environment overrides.",
+        "# Lines whose first non-space character is # are ignored.",
+        "# Edit this file to tune rclone without changing Sprinkle commands.",
+        "",
+    ]
+    for key, value in DEFAULT_RCLONE_ENV_VALUES:
+        lines.append("# " + comments[key])
+        lines.append("{}={}".format(key, value))
+    lines.append("")
+    return "\n".join(lines)
+
+
+def ensure_rclone_env_file(path):
+    path = os.path.abspath(os.path.expanduser(path))
+    if os.path.exists(path):
+        return path
+    parent = os.path.dirname(path)
+    if parent:
+        os.makedirs(parent, exist_ok=True)
+    with open(path, "w") as fp:
+        fp.write(default_rclone_env_text())
+    return path
+
+
+def apply_rclone_env_file(path):
+    if path in (None, ""):
+        return {}
+    path = ensure_rclone_env_file(path)
+    loaded = {}
+    with open(path, "r") as fp:
+        for line in fp:
+            line = line.strip()
+            if line == "" or line.startswith("#"):
+                continue
+            if "=" not in line:
+                logging.debug("ignoring invalid rclone env line in " + path)
+                continue
+            key, value = line.split("=", 1)
+            key = key.strip()
+            if key == "":
+                logging.debug("ignoring empty rclone env key in " + path)
+                continue
+            value = value.strip()
+            os.environ[key] = value
+            loaded[key] = value
+    logging.debug("loaded " + str(len(loaded)) + " rclone environment variables from " + path)
+    return loaded
 
 
 def warranty():
@@ -79,7 +147,8 @@ OPTIONS:
     -c, --conf {config file}     configuration file
     -d, --debug                  debug output (default:true)
     -h, --help                   help
-    -v, --version                print version
+    -v, --verbose                set RCLONE_VERBOSE=1 for rclone
+    --version                    print version
     --check-prereq               chech prerequisites
     --comp-method {size|md5}     compare method [size|md5] (default:size)
     --daemon-interval            interval for the daemon to execute in minutes (default:60)
@@ -95,6 +164,7 @@ OPTIONS:
     --log-file {file}            logs output to the specified file
     --no-cache                   turn off caching
     --rclone-conf {config file}  rclone configuration (default:None)
+    --rclone-env-file {file}     file with environment variables for rclone
     --rclone-sa-dir {dir}        build rclone config from service accounts
     --rclone-sa-count {num}      limit number of service accounts used
     --drive-id {id}              Google Drive folder ID for rclone config
@@ -108,7 +178,7 @@ OPTIONS:
     --rclone-move                use 'rclone move' instead of 'rclone copy' (default:false)
     --restore-duplicates         restore files if duplicates are found (default:false)
     --retries {num_retries}      number of retries (default:1)
-    --show-progress              show progress
+    --progress                   show progress
     --single-instance            make sure only 1 concurrent instance of sprinkle is running (default:False)
     --ls-stop-first              stop listing after first remote with files (default:true)
     """
@@ -465,6 +535,8 @@ def read_args(argv):
     global __comp_method
     global __rclone_exe
     global __rclone_conf
+    global __rclone_env_file
+    global __rclone_verbose
     global __drive_id
     global __display_unit
     global __rclone_retries
@@ -507,6 +579,8 @@ def read_args(argv):
     __comp_method = None
     __rclone_exe = None
     __rclone_conf = None
+    __rclone_env_file = None
+    __rclone_verbose = None
     __drive_id = None
     __display_unit = None
     __rclone_retries = None
@@ -548,11 +622,13 @@ def read_args(argv):
                                    ["help",
                                     "conf=",
                                     "debug",
+                                    "verbose",
                                     "version",
                                     "dist-type=",
                                     "comp-method=",
                                     "rclone-exe=",
                                     "rclone-conf=",
+                                    "rclone-env-file=",
                                     "rclone-sa-dir=",
                                     "rclone-sa-count=",
                                     "drive-id=",
@@ -567,6 +643,7 @@ def read_args(argv):
                                     "rclone-retries=",
                                     "rclone-move",
                                     "show-progress",
+                                    "progress",
                                     "dry-run",
                                     "delete-files",
                                     "restore-duplicates",
@@ -597,9 +674,11 @@ def read_args(argv):
         if opt in ('-h', '--help'):
             usage()
             sys.exit(0)
-        elif opt in ('-v', '--version'):
+        elif opt == '--version':
             version()
             sys.exit(0)
+        elif opt in ("-v", "--verbose"):
+            __rclone_verbose = True
         elif opt in ("-c", "--conf"):
             __configfile = arg
         elif opt in ("-d", "--debug"):
@@ -612,6 +691,8 @@ def read_args(argv):
             __rclone_exe = arg
         elif opt in ("--rclone-conf"):
             __rclone_conf = arg
+        elif opt in ("--rclone-env-file"):
+            __rclone_env_file = arg
         elif opt in ("--rclone-sa-dir"):
             __rclone_sa_dir = arg
         elif opt in ("--rclone-sa-count"):
@@ -641,7 +722,7 @@ def read_args(argv):
             __display_unit = arg
         elif opt in ("--rclone-retries"):
             __rclone_retries = int(arg)
-        elif opt in ("--show-progress"):
+        elif opt in ("--show-progress", "--progress"):
             __show_progress = True
         elif opt in ("--delete-files"):
             __delete_files = True
@@ -720,6 +801,7 @@ def configure(config_file):
         "display_unit": "G",
         "rclone_retries": '1',
         "drive_id": None,
+        "rclone_env_file": default_rclone_env_path(),
         "rclone_sa_dir": None,
         "rclone_sa_count": None,
         "log_file": None,
@@ -770,6 +852,9 @@ def configure(config_file):
 
     if __rclone_conf is not None:
         __config['rclone_config'] = __rclone_conf
+
+    if __rclone_env_file is not None:
+        __config['rclone_env_file'] = __rclone_env_file
 
     if __drive_id is not None:
         __config['drive_id'] = __drive_id
@@ -870,6 +955,10 @@ def configure(config_file):
 
     if __sa_group_size is not None:
         __config['sa_group_size'] = __sa_group_size
+
+    apply_rclone_env_file(__config.get('rclone_env_file'))
+    if __rclone_verbose is True:
+        os.environ["RCLONE_VERBOSE"] = "1"
 
 
 def normalize_config_types(config_values):
@@ -1089,6 +1178,8 @@ def config_command(prompt_func=input, output_path=None):
         os.makedirs(parent, exist_ok=True)
     with open(target, 'w') as fp:
         fp.write(content)
+    if os.path.abspath(os.path.expanduser(target)) == os.path.abspath(default_config_path()):
+        ensure_rclone_env_file(default_rclone_env_path())
     common.print_line('wrote ' + target)
     return target
 
@@ -1148,6 +1239,10 @@ debug={debug}
 # rclone_move: move files instead of copying them
 # rclone_move=false (copy files and keep sources) (default)
 rclone_move={rclone_move}
+
+# rclone_env_file: environment variables exported before invoking rclone.
+# Lines starting with # are ignored. The default file is created on first use.
+rclone_env_file=~/.sprinkle/rclone.env
 
 # delete_files: delete files after 1-way sync
 # delete_files=false (leave files not locally present on remote drives)

--- a/tests/test_rclone_move_option.py
+++ b/tests/test_rclone_move_option.py
@@ -1,8 +1,10 @@
 import sprinkle
 
-def test_rclone_move_option():
+def test_rclone_move_option(tmp_path):
     sprinkle.read_args([
         "--rclone-move",
+        "--rclone-env-file",
+        str(tmp_path / "rclone.env"),
         "ls",
     ])
     sprinkle.configure(None)

--- a/tests/test_rclone_sa_dir_option.py
+++ b/tests/test_rclone_sa_dir_option.py
@@ -25,6 +25,8 @@ def test_rclone_sa_dir_option(tmp_path):
         str(sa_dir),
         "--rclone-sa-count",
         "1",
+        "--rclone-env-file",
+        str(tmp_path / "rclone.env"),
         "--drive-id",
         "drive-id",
         "ls",

--- a/tests/test_service_accounts_unittest.py
+++ b/tests/test_service_accounts_unittest.py
@@ -281,6 +281,235 @@ class RCloneQuotaTest(unittest.TestCase):
 
 
 class ClSyncPlacementTest(unittest.TestCase):
+    def test_lsjson_results_are_cached_by_service_account_remote(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            source = os.path.join(tmp, "source")
+            store = os.path.join(tmp, "store")
+            db_path = os.path.join(tmp, "sa.sqlite3")
+            os.mkdir(source)
+            write_json(os.path.join(source, "one.json"), make_service_account("one@example.test"))
+            registry = service_accounts.ServiceAccountRegistry(db_path, store)
+            registry.import_paths([source])
+            account = registry.active_accounts()[0]
+            registry.assign_remote_names([{"remote": "dst101", "path": account["managed_path"]}])
+            calls = []
+            payload = json.dumps([{
+                "Path": "movie.mkv",
+                "Name": "movie.mkv",
+                "Size": 10,
+                "MimeType": "video/x-matroska",
+                "ModTime": "2024-01-01T00:00:00Z",
+                "IsDir": False,
+                "ID": "file-id",
+            }])
+
+            def make_sync():
+                sync = clsync.ClSync.__new__(clsync.ClSync)
+                sync._config = {
+                    "no_cache": False,
+                    "ls_stop_first": False,
+                }
+                sync._sa_registry = service_accounts.ServiceAccountRegistry(db_path, store)
+                sync._sa_refresh = "stale"
+                sync._compare_method = "size"
+                sync._cache = {}
+                sync._cache_counter = {}
+                sync._cache_invalidation_max = 10
+                sync.get_remotes = lambda: ["dst101:"]
+                sync._rclone = types.SimpleNamespace(
+                    lsjson=lambda remote, path, _args, _no_error: calls.append((remote, path)) or payload
+                )
+                return sync
+
+            first = make_sync()
+            self.assertIn("/Movies/movie.mkv", first.ls("/Movies"))
+            second = make_sync()
+            self.assertIn("/Movies/movie.mkv", second.ls("/Movies"))
+            self.assertEqual(calls, [("dst101:", "/Movies")])
+
+    def test_root_lsjson_cache_serves_subdirectory_listing(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            source = os.path.join(tmp, "source")
+            store = os.path.join(tmp, "store")
+            db_path = os.path.join(tmp, "sa.sqlite3")
+            os.mkdir(source)
+            write_json(os.path.join(source, "one.json"), make_service_account("one@example.test"))
+            registry = service_accounts.ServiceAccountRegistry(db_path, store)
+            registry.import_paths([source])
+            account = registry.active_accounts()[0]
+            registry.assign_remote_names([{"remote": "dst101", "path": account["managed_path"]}])
+            registry.update_ls_cache(account["id"], "/", json.dumps([{
+                "Path": "Movies/Aladin/movie.mkv",
+                "Name": "movie.mkv",
+                "Size": 10,
+                "MimeType": "video/x-matroska",
+                "ModTime": "2024-01-01T00:00:00Z",
+                "IsDir": False,
+                "ID": "file-id",
+            }]))
+            calls = []
+            sync = clsync.ClSync.__new__(clsync.ClSync)
+            sync._config = {
+                "no_cache": False,
+                "ls_stop_first": False,
+            }
+            sync._sa_registry = service_accounts.ServiceAccountRegistry(db_path, store)
+            sync._sa_refresh = "stale"
+            sync._compare_method = "size"
+            sync._cache = {}
+            sync._cache_counter = {}
+            sync._cache_invalidation_max = 10
+            sync.get_remotes = lambda: ["dst101:"]
+            sync._rclone = types.SimpleNamespace(
+                lsjson=lambda remote, path, _args, _no_error: calls.append((remote, path)) or "[]"
+            )
+
+            files = sync.ls("/Movies/Aladin")
+
+            self.assertIn("/Movies/Aladin/movie.mkv", files)
+            self.assertEqual(calls, [])
+
+    def test_drive_id_ls_stop_first_stops_after_empty_listing(self):
+        sync = clsync.ClSync.__new__(clsync.ClSync)
+        sync._config = {
+            "no_cache": False,
+            "ls_stop_first": True,
+            "drive_id": "drive-id",
+        }
+        sync._sa_registry = None
+        sync._sa_refresh = "stale"
+        sync._compare_method = "size"
+        sync._cache = {}
+        sync._cache_counter = {}
+        sync._cache_invalidation_max = 10
+        sync.get_remotes = lambda: ["dst101:", "dst102:", "dst103:"]
+        calls = []
+        sync._rclone = types.SimpleNamespace(
+            lsjson=lambda remote, path, _args, _no_error: calls.append((remote, path)) or "[]"
+        )
+
+        files = sync.ls("/Movies/Aladin")
+
+        self.assertEqual(files, {})
+        self.assertEqual(calls, [("dst101:", "/Movies/Aladin")])
+
+    def test_ls_shallow_omits_recursive_rclone_arg(self):
+        sync = clsync.ClSync.__new__(clsync.ClSync)
+        sync._config = {
+            "no_cache": False,
+            "ls_stop_first": True,
+        }
+        sync._sa_registry = None
+        sync._sa_refresh = "stale"
+        sync._compare_method = "size"
+        sync._cache = {}
+        sync._cache_counter = {}
+        sync._cache_invalidation_max = 10
+        sync.get_remotes = lambda: ["dst101:"]
+        calls = []
+        payload = json.dumps([{
+            "Path": "movie.mkv",
+            "Name": "movie.mkv",
+            "Size": 10,
+            "MimeType": "video/x-matroska",
+            "ModTime": "2024-01-01T00:00:00Z",
+            "IsDir": False,
+            "ID": "file-id",
+        }])
+        sync._rclone = types.SimpleNamespace(
+            lsjson=lambda remote, path, args, _no_error: calls.append((remote, path, args)) or payload
+        )
+
+        files = sync.ls_shallow("/Movies/Aladin")
+
+        self.assertIn("/Movies/Aladin/movie.mkv", files)
+        self.assertEqual(calls, [("dst101:", "/Movies/Aladin", ["--fast-list"])])
+
+    def test_backup_without_delete_files_uses_shallow_remote_listings(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            movie_dir = os.path.join(tmp, "Movies", "Aladin")
+            os.makedirs(movie_dir)
+            local_file = os.path.join(movie_dir, "movie.mkv")
+            with open(local_file, "w") as fp:
+                fp.write("synthetic movie")
+
+            sync = clsync.ClSync.__new__(clsync.ClSync)
+            sync._show_progress = False
+            sync._compare_method = "size"
+            sync._ClSync__exclusion_list = None
+            sync._ClSync__exclude_regex = None
+            sync.get_best_remote = lambda _size: "dst109:"
+            sync.mark_remote_used = lambda _remote, _size: None
+            shallow_paths = []
+            recursive_paths = []
+            copies = []
+            sync.ls_shallow = lambda path: shallow_paths.append(path) or {}
+            sync.ls = lambda path: recursive_paths.append(path) or {}
+            sync.copy = lambda src, dst, remote: copies.append((src, dst, remote))
+
+            old_cwd = os.getcwd()
+            try:
+                os.chdir(tmp)
+                sync.backup(movie_dir, delete_files=False, dry_run=False)
+            finally:
+                os.chdir(old_cwd)
+
+            self.assertEqual(shallow_paths, ["/Movies/Aladin"])
+            self.assertEqual(recursive_paths, [])
+            self.assertEqual(copies, [(local_file, "/Movies/Aladin", "dst109:")])
+
+    def test_sa_stats_refreshes_service_account_file_cache(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            source = os.path.join(tmp, "source")
+            store = os.path.join(tmp, "store")
+            db_path = os.path.join(tmp, "sa.sqlite3")
+            os.mkdir(source)
+            write_json(os.path.join(source, "one.json"), make_service_account("one@example.test"))
+            registry = service_accounts.ServiceAccountRegistry(db_path, store)
+            registry.import_paths([source])
+            old_quota = sprinkle._refresh_service_account_quota
+            old_file_cache = sprinkle._refresh_service_account_file_cache
+            old_print_line = common.print_line
+
+            try:
+                sprinkle._refresh_service_account_quota = (
+                    lambda _account: ({"total": 100, "used": 20, "free": 80}, None)
+                )
+                sprinkle._refresh_service_account_file_cache = (
+                    lambda _account: (json.dumps([{
+                        "Path": "Movies/Aladin/movie.mkv",
+                        "Name": "movie.mkv",
+                        "Size": 10,
+                        "MimeType": "video/x-matroska",
+                        "ModTime": "2024-01-01T00:00:00Z",
+                        "IsDir": False,
+                        "ID": "file-id",
+                    }]), None)
+                )
+                common.print_line = lambda _message="": None
+                sprinkle.read_args([
+                    "--sa-db",
+                    db_path,
+                    "--sa-store",
+                    store,
+                    "--sa-refresh",
+                    "all",
+                    "sa-stats",
+                ])
+                sprinkle.configure(None)
+                sprinkle.sa_stats()
+            finally:
+                sprinkle._refresh_service_account_quota = old_quota
+                sprinkle._refresh_service_account_file_cache = old_file_cache
+                common.print_line = old_print_line
+
+            cache_row = service_accounts.ServiceAccountRegistry(db_path, store).ls_cache_by_account_id(
+                registry.active_accounts()[0]["id"],
+                "/",
+            )
+            self.assertIsNotNone(cache_row)
+            self.assertEqual(cache_row["file_count"], 1)
+
     def test_backup_preserves_cwd_relative_directory_in_remote_destination(self):
         with tempfile.TemporaryDirectory() as tmp:
             movie_dir = os.path.join(tmp, "Movies", "Aladin")
@@ -298,7 +527,7 @@ class ClSyncPlacementTest(unittest.TestCase):
             sync.mark_remote_used = lambda _remote, _size: None
             listed_paths = []
             copies = []
-            sync.ls = lambda path: listed_paths.append(path) or {}
+            sync.ls_shallow = lambda path: listed_paths.append(path) or {}
             sync.copy = lambda src, dst, remote: copies.append((src, dst, remote))
 
             try:

--- a/tests/test_service_accounts_unittest.py
+++ b/tests/test_service_accounts_unittest.py
@@ -222,6 +222,45 @@ class RCloneQuotaTest(unittest.TestCase):
         self.assertIn("credentials rejected", friendly)
         self.assertIn("one@example.test", friendly)
 
+    def test_lsjson_ignores_rclone_progress_output(self):
+        old_execute = common.execute
+
+        def fake_execute(_command, no_error=False):
+            return {
+                "code": 0,
+                "out": "[\n]\nTransferred:   \t          0 B / 0 B, -, 0 B/s, ETA -\nElapsed time:         1.7s\n",
+                "error": "",
+            }
+
+        try:
+            common.execute = fake_execute
+            rc = rclone.RClone()
+            out = rc.lsjson("dst101:", "/Movies/Aladin", ["--fast-list"], True)
+        finally:
+            common.execute = old_execute
+
+        self.assertEqual(json.loads(out), [])
+
+    def test_about_json_ignores_rclone_progress_output(self):
+        old_execute = common.execute
+
+        def fake_execute(_command, no_error=False):
+            return {
+                "code": 0,
+                "out": '{"total": 100, "free": 75}\nTransferred:   \t0 B / 0 B, -, 0 B/s, ETA -\n',
+                "error": "",
+            }
+
+        try:
+            common.execute = fake_execute
+            rc = rclone.RClone()
+            quota, error = rc.get_about_json_with_error("dst101:")
+        finally:
+            common.execute = old_execute
+
+        self.assertIsNone(error)
+        self.assertEqual(quota["free"], 75)
+
     def test_unknown_quota_reason_requires_total_and_free(self):
         self.assertIn("missing total,free", sprinkle._quota_unknown_reason({"used": 1}))
         self.assertIsNone(sprinkle._quota_unknown_reason({"total": 100, "free": 0}))
@@ -494,6 +533,8 @@ class ClSyncPlacementTest(unittest.TestCase):
                     store,
                     "--sa-refresh",
                     "all",
+                    "--rclone-env-file",
+                    os.path.join(tmp, "rclone.env"),
                     "sa-stats",
                 ])
                 sprinkle.configure(None)
@@ -585,6 +626,127 @@ class ClSyncPlacementTest(unittest.TestCase):
 
 
 class ServiceAccountCliTest(unittest.TestCase):
+    def test_rclone_env_file_rolls_out_and_loads_defaults(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            env_path = os.path.join(tmp, "rclone.env")
+            keys = [key for key, _value in sprinkle.DEFAULT_RCLONE_ENV_VALUES]
+            old_env = dict((key, os.environ.get(key)) for key in keys)
+            try:
+                for key in keys:
+                    os.environ.pop(key, None)
+
+                loaded = sprinkle.apply_rclone_env_file(env_path)
+
+                self.assertTrue(os.path.exists(env_path))
+                with open(env_path) as fp:
+                    content = fp.read()
+                self.assertIn("# Lines whose first non-space character is # are ignored.", content)
+                self.assertEqual(loaded["RCLONE_DRIVE_CHUNK_SIZE"], "256M")
+                self.assertEqual(os.environ["RCLONE_SIZE_ONLY"], "1")
+                self.assertEqual(os.environ["RCLONE_NO_UPDATE_MODTIME"], "1")
+            finally:
+                for key, value in old_env.items():
+                    if value is None:
+                        os.environ.pop(key, None)
+                    else:
+                        os.environ[key] = value
+
+    def test_rclone_env_file_ignores_comments(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            env_path = os.path.join(tmp, "rclone.env")
+            with open(env_path, "w") as fp:
+                fp.write("\n".join([
+                    "# RCLONE_SIZE_ONLY=0",
+                    "  # RCLONE_NO_UPDATE_MODTIME=0",
+                    "RCLONE_DRIVE_CHUNK_SIZE=512M",
+                    "RCLONE_EXTRA=value=with=equals",
+                    "",
+                ]))
+            keys = [
+                "RCLONE_SIZE_ONLY",
+                "RCLONE_NO_UPDATE_MODTIME",
+                "RCLONE_DRIVE_CHUNK_SIZE",
+                "RCLONE_EXTRA",
+            ]
+            old_env = dict((key, os.environ.get(key)) for key in keys)
+            try:
+                for key in keys:
+                    os.environ.pop(key, None)
+
+                loaded = sprinkle.apply_rclone_env_file(env_path)
+
+                self.assertNotIn("RCLONE_SIZE_ONLY", loaded)
+                self.assertNotIn("RCLONE_NO_UPDATE_MODTIME", loaded)
+                self.assertEqual(os.environ["RCLONE_DRIVE_CHUNK_SIZE"], "512M")
+                self.assertEqual(os.environ["RCLONE_EXTRA"], "value=with=equals")
+            finally:
+                for key, value in old_env.items():
+                    if value is None:
+                        os.environ.pop(key, None)
+                    else:
+                        os.environ[key] = value
+
+    def test_configure_rolls_out_default_rclone_env_file(self):
+        old_home = os.environ.get("HOME")
+        keys = [key for key, _value in sprinkle.DEFAULT_RCLONE_ENV_VALUES]
+        old_env = dict((key, os.environ.get(key)) for key in keys)
+        with tempfile.TemporaryDirectory() as tmp:
+            try:
+                os.environ["HOME"] = tmp
+                for key in keys:
+                    os.environ.pop(key, None)
+
+                sprinkle.read_args(["stats"])
+                sprinkle.configure(None)
+
+                env_path = os.path.join(tmp, ".sprinkle", "rclone.env")
+                self.assertTrue(os.path.exists(env_path))
+                self.assertEqual(os.environ["RCLONE_DRIVE_CHUNK_SIZE"], "256M")
+                self.assertEqual(getattr(sprinkle, "__config")["rclone_env_file"], env_path)
+            finally:
+                if old_home is None:
+                    os.environ.pop("HOME", None)
+                else:
+                    os.environ["HOME"] = old_home
+                for key, value in old_env.items():
+                    if value is None:
+                        os.environ.pop(key, None)
+                    else:
+                        os.environ[key] = value
+
+    def test_dash_v_sets_rclone_verbose(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            old_verbose = os.environ.get("RCLONE_VERBOSE")
+            try:
+                os.environ.pop("RCLONE_VERBOSE", None)
+                sprinkle.read_args([
+                    "-v",
+                    "--rclone-env-file",
+                    os.path.join(tmp, "rclone.env"),
+                    "stats",
+                ])
+                sprinkle.configure(None)
+
+                self.assertEqual(os.environ["RCLONE_VERBOSE"], "1")
+            finally:
+                if old_verbose is None:
+                    os.environ.pop("RCLONE_VERBOSE", None)
+                else:
+                    os.environ["RCLONE_VERBOSE"] = old_verbose
+
+    def test_progress_option_sets_show_progress(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            sprinkle.read_args([
+                "--progress",
+                "--rclone-env-file",
+                os.path.join(tmp, "rclone.env"),
+                "backup",
+                "/tmp/local",
+            ])
+            sprinkle.configure(None)
+
+            self.assertTrue(getattr(sprinkle, "__config")["show_progress"])
+
     def test_rclone_sa_dir_imports_deduped_managed_accounts(self):
         with tempfile.TemporaryDirectory() as tmp:
             source = os.path.join(tmp, "source")
@@ -602,6 +764,8 @@ class ServiceAccountCliTest(unittest.TestCase):
                 "1",
                 "--drive-id",
                 "drive-id",
+                "--rclone-env-file",
+                os.path.join(tmp, "rclone.env"),
                 "--sa-db",
                 db_path,
                 "--sa-store",
@@ -639,6 +803,8 @@ class ServiceAccountCliTest(unittest.TestCase):
                 sprinkle.read_args([
                     "--drive-id",
                     "drive-id",
+                    "--rclone-env-file",
+                    os.path.join(tmp, "rclone.env"),
                     "--sa-db",
                     db_path,
                     "--sa-store",
@@ -687,6 +853,7 @@ class ServiceAccountCliTest(unittest.TestCase):
             self.assertIn("sa_refresh=stale", content)
             self.assertIn("sa_clean_invalid=quarantine", content)
             self.assertIn("ls_stop_first=true", content)
+            self.assertIn("rclone_env_file=~/.sprinkle/rclone.env", content)
             self.assertIn("large_file_threshold_bytes=1073741824", content)
 
     def test_config_command_defaults_to_home_sprinkle_config_path(self):
@@ -702,6 +869,7 @@ class ServiceAccountCliTest(unittest.TestCase):
                 target = sprinkle.config_command(prompt)
                 self.assertEqual(target, os.path.join(tmp, ".sprinkle", "sprinkle.conf"))
                 self.assertTrue(os.path.exists(target))
+                self.assertTrue(os.path.exists(os.path.join(tmp, ".sprinkle", "rclone.env")))
             finally:
                 if old_home is None:
                     os.environ.pop("HOME", None)
@@ -725,6 +893,7 @@ class ServiceAccountCliTest(unittest.TestCase):
                     "rclone_sa_count=1",
                     "drive_id=drive-id",
                     "rclone_sa_dir=" + source,
+                    "rclone_env_file=" + os.path.join(tmp, "rclone.env"),
                     "sa_db=" + db_path,
                     "sa_store=" + store,
                 ]))


### PR DESCRIPTION
Since the original [`mmontuori/sprinkle`](https://github.com/mmontuori/sprinkle) 1.0.0 baseline, we prepared a 1.1.0 release with these main changes:

## Main Features
- Added Google Drive service-account import, deduplication, validation, quarantine handling, and SQLite-backed quota/listing cache.
- `sa-import` command to load many sa accounts from folder & sort them.
-  `sa-stats`  shows overview about all sa accounts & are cached outputs.
-  `backup` command works now much more flexible.


## Other 
- Improved backup performance for many service accounts by avoiding full recursive remote listings when `delete_files=false`.
- Fixed `--ls-stop-first` behavior so missing Drive folders do not scan every service-account remote.
- Added capacity-aware large-file placement with free-space headroom checks.
- Added `rclone_env_file` / `--rclone-env-file`, auto-creating `~/.sprinkle/rclone.env` with rclone defaults.
- Added rclone defaults: `RCLONE_DRIVE_CHUNK_SIZE=256M`, `RCLONE_SIZE_ONLY=1`, `RCLONE_NO_UPDATE_MODTIME=1`.
- Renamed user-facing progress option to `--progress`; kept `--show-progress` as compatibility alias.
- Changed `-v` / `--verbose` to set `RCLONE_VERBOSE=1`; version output remains `--version`.
- Updated package/module/snap versions to `1.1.0`, plus README, guide, config docs, changelog, and regression tests.



    ##### import service accounts:
    ```
    $ python3 sprinkle.py sa-import /path/to/service-accounts
    service account import: found 46 json files
    service account import [1/46] imported: sa-77757096d8ee3b33cf290d6a.json
    service account import [2/46] imported: sa-774a8b4465f01f42f1e45016.json
    ...
    service account import complete
    scanned:      46
    validated:    46
    imported:     46
    duplicates:   0
    invalid:      0
    validation errors: 0
    quarantined:  0
    deleted:      0
    store:        /home/user/.sprinkle/service-accounts
    database:     /home/user/.sprinkle/sa-cache.sqlite3
    ```
    
    
    ##### inspect imported accounts and cached quota:
    ```
    $ python3 sprinkle.py --drive-id GDRIVE_FOLDER_ID sa-stats
    SERVICE ACCOUNT SUMMARY
    active:      46
    duplicates:  0
    invalid:     0
    refreshed:   0
    errors:      0
    stale:       0
    unknown:     0
    
    ACCOUNT                                              SIZE         USED         FREE    %FREE UPDATED              ERROR
    ============================================ ============ ============ ============ ======== ==================== ====================
    .....
    sa5s.......           11.iam.gser...          15G           2G          12G       80 2026-05-25T16:35:04Z
    -------------------------------------------- ------------ ------------ ------------ -------- -------------------- --------------------
    total:                                               525G         371G         153G       29
    
    ```
